### PR TITLE
feat: add indoor humidity, HP coil temp, and HP stage sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,12 @@ impersonating a SAM (System Access Module).
 | HVAC | Climate | Mode (off/heat/cool/auto), fan (auto/low/med/high), heat+cool setpoints, current temperature |
 | Allow Control | Switch | Enables HVAC control from HA (default: OFF — see [Read-Only Mode](#read-only-mode)) |
 | Outdoor Temperature | Sensor | Outdoor air temp in °F (from heat pump 3E01 if available, otherwise from thermostat 3B02) |
+| Indoor Humidity | Sensor | Indoor relative humidity (%) from thermostat |
 | Airflow CFM | Sensor | Air handler airflow in CFM |
 | Blower Running | Binary Sensor | Whether the blower is running |
 | Heat Stage | Sensor | Current heat stage (0=off, 1=low, 2=med, 3=high) |
+| HP Coil Temperature | Sensor | Heat pump coil temperature in °F |
+| HP Stage | Sensor | Heat pump compressor stage |
 
 > **Note:** Only **Zone 1** is currently supported. Multi-zone systems will only see data for the first zone. See [TODO.md](TODO.md) for planned multi-zone support.
 

--- a/TODO.md
+++ b/TODO.md
@@ -25,9 +25,6 @@ The physical thermostat behaves differently:
 
 ## Additional Sensors
 
-- **Indoor humidity** — already parsed from 3B02 but not published as a sensor entity
-- **Heat pump coil temperature** — already parsed from 3E01 but not published
-- **Heat pump stage** — already parsed from 3E02 but not published
 - **Communication health** — add a "Last Successful Poll" timestamp sensor and a "Communication OK" binary sensor that goes false if no successful response is received within a configurable timeout
 
 ## Entity Improvements

--- a/abcdesp.yaml
+++ b/abcdesp.yaml
@@ -66,6 +66,29 @@ sensor:
     icon: "mdi:fire"
     state_class: measurement
 
+  - platform: template
+    name: "Indoor Humidity"
+    id: indoor_humidity
+    unit_of_measurement: "%"
+    accuracy_decimals: 0
+    device_class: humidity
+    state_class: measurement
+
+  - platform: template
+    name: "HP Coil Temperature"
+    id: hp_coil_temp
+    unit_of_measurement: "°F"
+    accuracy_decimals: 1
+    device_class: temperature
+    state_class: measurement
+
+  - platform: template
+    name: "HP Stage"
+    id: hp_stage
+    accuracy_decimals: 0
+    icon: "mdi:heat-pump"
+    state_class: measurement
+
 binary_sensor:
   - platform: template
     name: "Blower Running"
@@ -92,3 +115,6 @@ abcdesp:
   blower_sensor: blower_running
   heat_stage_sensor: heat_stage
   allow_control_switch: allow_control
+  indoor_humidity_sensor: indoor_humidity
+  hp_coil_temp_sensor: hp_coil_temp
+  hp_stage_sensor: hp_stage

--- a/components/abcdesp/__init__.py
+++ b/components/abcdesp/__init__.py
@@ -17,6 +17,9 @@ CONF_AIRFLOW_CFM_SENSOR = "airflow_cfm_sensor"
 CONF_BLOWER_SENSOR = "blower_sensor"
 CONF_HEAT_STAGE_SENSOR = "heat_stage_sensor"
 CONF_ALLOW_CONTROL_SWITCH = "allow_control_switch"
+CONF_INDOOR_HUMIDITY_SENSOR = "indoor_humidity_sensor"
+CONF_HP_COIL_TEMP_SENSOR = "hp_coil_temp_sensor"
+CONF_HP_STAGE_SENSOR = "hp_stage_sensor"
 
 CONFIG_SCHEMA = (
     climate.climate_schema(AbcdEspComponent)
@@ -28,6 +31,9 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_BLOWER_SENSOR): cv.use_id(binary_sensor.BinarySensor),
             cv.Optional(CONF_HEAT_STAGE_SENSOR): cv.use_id(sensor.Sensor),
             cv.Optional(CONF_ALLOW_CONTROL_SWITCH): cv.use_id(switch.Switch),
+            cv.Optional(CONF_INDOOR_HUMIDITY_SENSOR): cv.use_id(sensor.Sensor),
+            cv.Optional(CONF_HP_COIL_TEMP_SENSOR): cv.use_id(sensor.Sensor),
+            cv.Optional(CONF_HP_STAGE_SENSOR): cv.use_id(sensor.Sensor),
         }
     )
     .extend(uart.UART_DEVICE_SCHEMA)
@@ -61,3 +67,15 @@ async def to_code(config):
     if CONF_ALLOW_CONTROL_SWITCH in config:
         sw = await cg.get_variable(config[CONF_ALLOW_CONTROL_SWITCH])
         cg.add(var.set_allow_control_switch(sw))
+
+    if CONF_INDOOR_HUMIDITY_SENSOR in config:
+        sens = await cg.get_variable(config[CONF_INDOOR_HUMIDITY_SENSOR])
+        cg.add(var.set_indoor_humidity_sensor(sens))
+
+    if CONF_HP_COIL_TEMP_SENSOR in config:
+        sens = await cg.get_variable(config[CONF_HP_COIL_TEMP_SENSOR])
+        cg.add(var.set_hp_coil_temp_sensor(sens))
+
+    if CONF_HP_STAGE_SENSOR in config:
+        sens = await cg.get_variable(config[CONF_HP_STAGE_SENSOR])
+        cg.add(var.set_hp_stage_sensor(sens))

--- a/components/abcdesp/abcdesp.cpp
+++ b/components/abcdesp/abcdesp.cpp
@@ -536,6 +536,7 @@ void AbcdEspComponent::parse_heatpump_02(const uint8_t *data,
   }
   hp_stage_ = data[0] >> 1;
   ESP_LOGD(TAG, "3E02: HP stage=%d", hp_stage_);
+  publish_sensors();
 }
 
 // ==========================================================================
@@ -792,6 +793,18 @@ void AbcdEspComponent::publish_sensors() {
   if (heat_stage_sensor_ != nullptr) {
     heat_stage_sensor_->publish_state(static_cast<float>(heat_stage_));
   }
+
+  if (indoor_humidity_sensor_ != nullptr) {
+    indoor_humidity_sensor_->publish_state(static_cast<float>(indoor_humidity_));
+  }
+
+  if (hp_coil_temp_sensor_ != nullptr && !std::isnan(hp_coil_temp_)) {
+    hp_coil_temp_sensor_->publish_state(hp_coil_temp_);
+  }
+
+  if (hp_stage_sensor_ != nullptr) {
+    hp_stage_sensor_->publish_state(static_cast<float>(hp_stage_));
+  }
 }
 
 // ==========================================================================
@@ -809,6 +822,9 @@ void AbcdEspComponent::dump_config() {
   LOG_SENSOR("  ", "Airflow CFM", airflow_cfm_sensor_);
   LOG_BINARY_SENSOR("  ", "Blower", blower_sensor_);
   LOG_SENSOR("  ", "Heat Stage", heat_stage_sensor_);
+  LOG_SENSOR("  ", "Indoor Humidity", indoor_humidity_sensor_);
+  LOG_SENSOR("  ", "HP Coil Temp", hp_coil_temp_sensor_);
+  LOG_SENSOR("  ", "HP Stage", hp_stage_sensor_);
 }
 
 }  // namespace abcdesp

--- a/components/abcdesp/abcdesp.h
+++ b/components/abcdesp/abcdesp.h
@@ -92,6 +92,9 @@ class AbcdEspComponent : public Component,
   void set_blower_sensor(binary_sensor::BinarySensor *s) { blower_sensor_ = s; }
   void set_heat_stage_sensor(sensor::Sensor *s) { heat_stage_sensor_ = s; }
   void set_allow_control_switch(switch_::Switch *sw) { allow_control_switch_ = sw; }
+  void set_indoor_humidity_sensor(sensor::Sensor *s) { indoor_humidity_sensor_ = s; }
+  void set_hp_coil_temp_sensor(sensor::Sensor *s) { hp_coil_temp_sensor_ = s; }
+  void set_hp_stage_sensor(sensor::Sensor *s) { hp_stage_sensor_ = s; }
 
   // Component overrides
   void setup() override;
@@ -178,6 +181,9 @@ class AbcdEspComponent : public Component,
   sensor::Sensor *airflow_cfm_sensor_{nullptr};
   binary_sensor::BinarySensor *blower_sensor_{nullptr};
   sensor::Sensor *heat_stage_sensor_{nullptr};
+  sensor::Sensor *indoor_humidity_sensor_{nullptr};
+  sensor::Sensor *hp_coil_temp_sensor_{nullptr};
+  sensor::Sensor *hp_stage_sensor_{nullptr};
 
   // Control gate
   switch_::Switch *allow_control_switch_{nullptr};


### PR DESCRIPTION
Expose three sensors that were already being parsed from the bus but not published to Home Assistant:

- **Indoor Humidity** (%) — from thermostat register 3B02
- **HP Coil Temperature** (°F) — from heat pump register 3E01
- **HP Stage** — compressor stage from heat pump register 3E02

Also fixes a missing `publish_sensors()` call in `parse_heatpump_02()`, updates the README entity table, and removes completed items from TODO.md.