### PR TITLE
fix: diagnostic entity categories and Celsius temperature steps

### DIFF
--- a/abcdesp.yaml
+++ b/abcdesp.yaml
@@ -59,6 +59,7 @@ sensor:
     accuracy_decimals: 0
     icon: "mdi:fan"
     state_class: measurement
+    entity_category: diagnostic
 
   - platform: template
     name: "Heat Stage"
@@ -66,6 +67,7 @@ sensor:
     accuracy_decimals: 0
     icon: "mdi:fire"
     state_class: measurement
+    entity_category: diagnostic
 
   - platform: template
     name: "Indoor Humidity"
@@ -82,6 +84,7 @@ sensor:
     accuracy_decimals: 1
     device_class: temperature
     state_class: measurement
+    entity_category: diagnostic
 
   - platform: template
     name: "HP Stage"
@@ -89,16 +92,19 @@ sensor:
     accuracy_decimals: 0
     icon: "mdi:heat-pump"
     state_class: measurement
+    entity_category: diagnostic
 
 binary_sensor:
   - platform: template
     name: "Blower Running"
     id: blower_running
+    entity_category: diagnostic
 
   - platform: template
     name: "Communication OK"
     id: comms_ok
     device_class: connectivity
+    entity_category: diagnostic
 
 switch:
   - platform: template

--- a/components/abcdesp/abcdesp.cpp
+++ b/components/abcdesp/abcdesp.cpp
@@ -573,7 +573,8 @@ climate::ClimateTraits AbcdEspComponent::traits() {
                            climate::CLIMATE_REQUIRES_TWO_POINT_TARGET_TEMPERATURE);
   traits.set_visual_min_temperature(f_to_c(40));   // 40°F ≈ 4.4°C
   traits.set_visual_max_temperature(f_to_c(99));   // 99°F ≈ 37.2°C
-  traits.set_visual_temperature_step(f_to_c(33));  // 1°F step ≈ 0.56°C
+  traits.set_visual_target_temperature_step(0.5);   // 0.5°C step, rounds to nearest °F
+  traits.set_visual_current_temperature_step(0.1);  // 0.1°C for display precision
 
   traits.set_supported_modes({
       climate::CLIMATE_MODE_OFF,


### PR DESCRIPTION
Two improvements for HA usability:

### Diagnostic entity categories
Tag sensors that are operational/debugging data with `entity_category: diagnostic` so they're hidden from the default HA dashboard:
- Airflow CFM, Heat Stage, HP Coil Temperature, HP Stage, Blower Running, Communication OK

User-facing entities (Climate, Outdoor Temperature, Indoor Humidity, Allow Control) remain on the main card.

### Celsius temperature steps
Use separate visual steps for the climate entity:
- **Target temperature step: 0.5°C** — cleaner increments for the UI (each step rounds to nearest °F on the bus)
- **Current temperature step: 0.1°C** — accurate display of converted sensor values

Previously used a single 0.556°C step (exact 1°F conversion) which produced ugly display values like 20.0, 20.6, 21.1°C.