### PR TITLE
refactor: define sensors inside climate block

### DIFF
--- a/abcdesp.yaml
+++ b/abcdesp.yaml
@@ -43,69 +43,6 @@ uart:
   stop_bits: 1
   parity: NONE
 
-sensor:
-  - platform: template
-    name: "Outdoor Temperature"
-    id: outdoor_temp
-    unit_of_measurement: "°F"
-    accuracy_decimals: 1
-    device_class: temperature
-    state_class: measurement
-
-  - platform: template
-    name: "Airflow CFM"
-    id: airflow_cfm
-    unit_of_measurement: "CFM"
-    accuracy_decimals: 0
-    icon: "mdi:fan"
-    state_class: measurement
-    entity_category: diagnostic
-
-  - platform: template
-    name: "Heat Stage"
-    id: heat_stage
-    accuracy_decimals: 0
-    icon: "mdi:fire"
-    state_class: measurement
-    entity_category: diagnostic
-
-  - platform: template
-    name: "Indoor Humidity"
-    id: indoor_humidity
-    unit_of_measurement: "%"
-    accuracy_decimals: 0
-    device_class: humidity
-    state_class: measurement
-
-  - platform: template
-    name: "HP Coil Temperature"
-    id: hp_coil_temp
-    unit_of_measurement: "°F"
-    accuracy_decimals: 1
-    device_class: temperature
-    state_class: measurement
-    entity_category: diagnostic
-
-  - platform: template
-    name: "HP Stage"
-    id: hp_stage
-    accuracy_decimals: 0
-    icon: "mdi:heat-pump"
-    state_class: measurement
-    entity_category: diagnostic
-
-binary_sensor:
-  - platform: template
-    name: "Blower Running"
-    id: blower_running
-    entity_category: diagnostic
-
-  - platform: template
-    name: "Communication OK"
-    id: comms_ok
-    device_class: connectivity
-    entity_category: diagnostic
-
 switch:
   - platform: template
     name: "Allow Control"
@@ -116,17 +53,26 @@ switch:
 
 abcdesp:
   name: "HVAC"
+  icon: "mdi:hvac"
   uart_id: abcdesp_uart
   flow_pin:
     number: GPIO4
     mode:
       output: true
-  outdoor_temp_sensor: outdoor_temp
-  airflow_cfm_sensor: airflow_cfm
-  blower_sensor: blower_running
-  heat_stage_sensor: heat_stage
   allow_control_switch: allow_control
-  indoor_humidity_sensor: indoor_humidity
-  hp_coil_temp_sensor: hp_coil_temp
-  hp_stage_sensor: hp_stage
-  comms_ok_sensor: comms_ok
+  outdoor_temp_sensor:
+    name: "Outdoor Temperature"
+  indoor_humidity_sensor:
+    name: "Indoor Humidity"
+  airflow_cfm_sensor:
+    name: "Airflow CFM"
+  heat_stage_sensor:
+    name: "Heat Stage"
+  hp_coil_temp_sensor:
+    name: "HP Coil Temperature"
+  hp_stage_sensor:
+    name: "HP Stage"
+  blower_sensor:
+    name: "Blower Running"
+  comms_ok_sensor:
+    name: "Communication OK"

--- a/components/abcdesp/__init__.py
+++ b/components/abcdesp/__init__.py
@@ -132,11 +132,3 @@ async def to_code(config):
     if CONF_ALLOW_CONTROL_SWITCH in config:
         sw = await cg.get_variable(config[CONF_ALLOW_CONTROL_SWITCH])
         cg.add(var.set_allow_control_switch(sw))
-
-    if CONF_HP_STAGE_SENSOR in config:
-        sens = await cg.get_variable(config[CONF_HP_STAGE_SENSOR])
-        cg.add(var.set_hp_stage_sensor(sens))
-
-    if CONF_COMMS_OK_SENSOR in config:
-        sens = await cg.get_variable(config[CONF_COMMS_OK_SENSOR])
-        cg.add(var.set_comms_ok_sensor(sens))

--- a/components/abcdesp/__init__.py
+++ b/components/abcdesp/__init__.py
@@ -1,10 +1,20 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import climate, sensor, binary_sensor, switch, uart
+from esphome.const import (
+    DEVICE_CLASS_HUMIDITY,
+    DEVICE_CLASS_TEMPERATURE,
+    DEVICE_CLASS_CONNECTIVITY,
+    ENTITY_CATEGORY_DIAGNOSTIC,
+    ICON_FAN,
+    STATE_CLASS_MEASUREMENT,
+    UNIT_CELSIUS,
+    UNIT_PERCENT,
+)
 from esphome import pins
 
 DEPENDENCIES = ["uart"]
-AUTO_LOAD = ["climate"]
+AUTO_LOAD = ["climate", "sensor", "binary_sensor"]
 
 abcdesp_ns = cg.esphome_ns.namespace("abcdesp")
 AbcdEspComponent = abcdesp_ns.class_(
@@ -27,15 +37,52 @@ CONFIG_SCHEMA = (
     .extend(
         {
             cv.Optional(CONF_FLOW_PIN): pins.gpio_output_pin_schema,
-            cv.Optional(CONF_OUTDOOR_TEMP_SENSOR): cv.use_id(sensor.Sensor),
-            cv.Optional(CONF_AIRFLOW_CFM_SENSOR): cv.use_id(sensor.Sensor),
-            cv.Optional(CONF_BLOWER_SENSOR): cv.use_id(binary_sensor.BinarySensor),
-            cv.Optional(CONF_HEAT_STAGE_SENSOR): cv.use_id(sensor.Sensor),
+            cv.Optional(CONF_OUTDOOR_TEMP_SENSOR): sensor.sensor_schema(
+                unit_of_measurement="°F",
+                accuracy_decimals=1,
+                device_class=DEVICE_CLASS_TEMPERATURE,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_INDOOR_HUMIDITY_SENSOR): sensor.sensor_schema(
+                unit_of_measurement=UNIT_PERCENT,
+                accuracy_decimals=0,
+                device_class=DEVICE_CLASS_HUMIDITY,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_AIRFLOW_CFM_SENSOR): sensor.sensor_schema(
+                unit_of_measurement="CFM",
+                accuracy_decimals=0,
+                icon=ICON_FAN,
+                state_class=STATE_CLASS_MEASUREMENT,
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+            ),
+            cv.Optional(CONF_HEAT_STAGE_SENSOR): sensor.sensor_schema(
+                accuracy_decimals=0,
+                icon="mdi:fire",
+                state_class=STATE_CLASS_MEASUREMENT,
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+            ),
+            cv.Optional(CONF_HP_COIL_TEMP_SENSOR): sensor.sensor_schema(
+                unit_of_measurement="°F",
+                accuracy_decimals=1,
+                device_class=DEVICE_CLASS_TEMPERATURE,
+                state_class=STATE_CLASS_MEASUREMENT,
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+            ),
+            cv.Optional(CONF_HP_STAGE_SENSOR): sensor.sensor_schema(
+                accuracy_decimals=0,
+                icon="mdi:heat-pump",
+                state_class=STATE_CLASS_MEASUREMENT,
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+            ),
+            cv.Optional(CONF_BLOWER_SENSOR): binary_sensor.binary_sensor_schema(
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+            ),
+            cv.Optional(CONF_COMMS_OK_SENSOR): binary_sensor.binary_sensor_schema(
+                device_class=DEVICE_CLASS_CONNECTIVITY,
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+            ),
             cv.Optional(CONF_ALLOW_CONTROL_SWITCH): cv.use_id(switch.Switch),
-            cv.Optional(CONF_INDOOR_HUMIDITY_SENSOR): cv.use_id(sensor.Sensor),
-            cv.Optional(CONF_HP_COIL_TEMP_SENSOR): cv.use_id(sensor.Sensor),
-            cv.Optional(CONF_HP_STAGE_SENSOR): cv.use_id(sensor.Sensor),
-            cv.Optional(CONF_COMMS_OK_SENSOR): cv.use_id(binary_sensor.BinarySensor),
         }
     )
     .extend(uart.UART_DEVICE_SCHEMA)
@@ -51,32 +98,40 @@ async def to_code(config):
         cg.add(var.set_flow_pin(flow_pin))
 
     if CONF_OUTDOOR_TEMP_SENSOR in config:
-        sens = await cg.get_variable(config[CONF_OUTDOOR_TEMP_SENSOR])
+        sens = await sensor.new_sensor(config[CONF_OUTDOOR_TEMP_SENSOR])
         cg.add(var.set_outdoor_temp_sensor(sens))
 
+    if CONF_INDOOR_HUMIDITY_SENSOR in config:
+        sens = await sensor.new_sensor(config[CONF_INDOOR_HUMIDITY_SENSOR])
+        cg.add(var.set_indoor_humidity_sensor(sens))
+
     if CONF_AIRFLOW_CFM_SENSOR in config:
-        sens = await cg.get_variable(config[CONF_AIRFLOW_CFM_SENSOR])
+        sens = await sensor.new_sensor(config[CONF_AIRFLOW_CFM_SENSOR])
         cg.add(var.set_airflow_cfm_sensor(sens))
 
+    if CONF_HEAT_STAGE_SENSOR in config:
+        sens = await sensor.new_sensor(config[CONF_HEAT_STAGE_SENSOR])
+        cg.add(var.set_heat_stage_sensor(sens))
+
+    if CONF_HP_COIL_TEMP_SENSOR in config:
+        sens = await sensor.new_sensor(config[CONF_HP_COIL_TEMP_SENSOR])
+        cg.add(var.set_hp_coil_temp_sensor(sens))
+
+    if CONF_HP_STAGE_SENSOR in config:
+        sens = await sensor.new_sensor(config[CONF_HP_STAGE_SENSOR])
+        cg.add(var.set_hp_stage_sensor(sens))
+
     if CONF_BLOWER_SENSOR in config:
-        sens = await cg.get_variable(config[CONF_BLOWER_SENSOR])
+        sens = await binary_sensor.new_binary_sensor(config[CONF_BLOWER_SENSOR])
         cg.add(var.set_blower_sensor(sens))
 
-    if CONF_HEAT_STAGE_SENSOR in config:
-        sens = await cg.get_variable(config[CONF_HEAT_STAGE_SENSOR])
-        cg.add(var.set_heat_stage_sensor(sens))
+    if CONF_COMMS_OK_SENSOR in config:
+        sens = await binary_sensor.new_binary_sensor(config[CONF_COMMS_OK_SENSOR])
+        cg.add(var.set_comms_ok_sensor(sens))
 
     if CONF_ALLOW_CONTROL_SWITCH in config:
         sw = await cg.get_variable(config[CONF_ALLOW_CONTROL_SWITCH])
         cg.add(var.set_allow_control_switch(sw))
-
-    if CONF_INDOOR_HUMIDITY_SENSOR in config:
-        sens = await cg.get_variable(config[CONF_INDOOR_HUMIDITY_SENSOR])
-        cg.add(var.set_indoor_humidity_sensor(sens))
-
-    if CONF_HP_COIL_TEMP_SENSOR in config:
-        sens = await cg.get_variable(config[CONF_HP_COIL_TEMP_SENSOR])
-        cg.add(var.set_hp_coil_temp_sensor(sens))
 
     if CONF_HP_STAGE_SENSOR in config:
         sens = await cg.get_variable(config[CONF_HP_STAGE_SENSOR])


### PR DESCRIPTION
Move all sensor and binary sensor definitions from standalone template entities into sub-schemas of the `abcdesp:` climate config block, matching the pattern used by other ESPHome climate integrations (e.g., cn105).

### Before
```yaml
sensor:
  - platform: template
    name: "Outdoor Temperature"
    id: outdoor_temp
    unit_of_measurement: "°F"
    accuracy_decimals: 1
    device_class: temperature
    state_class: measurement
# ... 6 more template sensors ...

abcdesp:
  outdoor_temp_sensor: outdoor_temp
```

### After
```yaml
abcdesp:
  outdoor_temp_sensor:
    name: "Outdoor Temperature"
```

All sensor metadata (unit, device_class, entity_category, icon, etc.) is now baked into the component's Python schema — users just provide a name.

### Changes
- `__init__.py`: Use `sensor.sensor_schema()` / `binary_sensor.binary_sensor_schema()` with all metadata; `AUTO_LOAD` includes `sensor` and `binary_sensor`
- `abcdesp.yaml`: Remove standalone sensor/binary_sensor blocks; define inline
- Add `icon: mdi:hvac` to the climate entity
- Allow Control switch remains external (template switch with `optimistic` and `restore_mode`)