### PR TITLE
Climate entity polish: humidity, action logic, sensor dedup, dump_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ impersonating a SAM (System Access Module).
 
 | Entity | Type | Description |
 |--------|------|-------------|
-| HVAC | Climate | Mode (off/heat/cool/auto), fan (auto/low/med/high), heat+cool setpoints, current temperature |
+| HVAC | Climate | Mode (off/heat/cool/auto), fan (auto/low/med/high), heat+cool setpoints, current temperature and humidity |
 | Allow Control | Switch | Enables HVAC control from HA (default: OFF — see [Read-Only Mode](#read-only-mode)) |
 | Outdoor Temperature | Sensor | Outdoor air temp in °F (from heat pump 3E01 if available, otherwise from thermostat 3B02) |
 | Indoor Humidity | Sensor | Indoor relative humidity (%) from thermostat |
@@ -58,6 +58,8 @@ impersonating a SAM (System Access Module).
 | Communication OK | Binary Sensor | Whether the ESP32 is receiving responses from the thermostat (goes offline after 30s of no response) |
 
 > **Note:** Only **Zone 1** is currently supported. Multi-zone systems will only see data for the first zone. See [TODO.md](TODO.md) for planned multi-zone support.
+
+> **Temperature units:** All sensors report in °F internally. Home Assistant automatically converts values to match your configured unit system (°C or °F), so temperatures will display correctly regardless of your HA settings.
 
 ## How It Works
 

--- a/TODO.md
+++ b/TODO.md
@@ -30,8 +30,12 @@ _(All planned sensors have been implemented.)_
 ## Entity Improvements
 
 - **Heat stage labels** — map raw heat stage values (0–3) to meaningful labels (off/low/med/high) via a text sensor or HA template
+- **Single vs. dual setpoint by mode** — show one target temperature in heat/cool mode, two in auto
+- **Fan-only mode** — expose fan-only operation via the climate entity
+- **Away/vacation preset** — map Carrier vacation hold to HA climate presets
+- **Internalize Allow Control switch** — register the switch inside the component instead of requiring a separate `switch:` block in YAML
 
 ## Other
 
-- **Web server** — add ESPHome `web_server` component for local debugging without Home Assistant
+- **Bus device detection** — log which devices (thermostat, air handler, heat pump) are detected on the bus and warn about missing ones
 - **Unique ID handling** — document behavior for users with multiple ESP32 units

--- a/components/abcdesp/abcdesp.cpp
+++ b/components/abcdesp/abcdesp.cpp
@@ -738,6 +738,9 @@ void AbcdEspComponent::publish_climate_state() {
     this->current_temperature = f_to_c(indoor_temp_);
   }
 
+  // Current humidity
+  this->current_humidity = static_cast<float>(indoor_humidity_);
+
   // Target temperatures (convert °F → °C for HA)
   this->target_temperature_low = f_to_c(static_cast<float>(heat_setpoint_));
   this->target_temperature_high = f_to_c(static_cast<float>(cool_setpoint_));
@@ -776,23 +779,26 @@ void AbcdEspComponent::publish_climate_state() {
       break;
   }
 
-  // Action
+  // Action — use real stage data from air handler and heat pump
   if (current_mode_ == MODE_OFF) {
     this->action = climate::CLIMATE_ACTION_OFF;
-  } else if (blower_running_) {
-    if (heat_stage_ > 0) {
-      this->action = climate::CLIMATE_ACTION_HEATING;
-    } else if (current_mode_ == MODE_COOL ||
-             (current_mode_ == MODE_AUTO && !std::isnan(indoor_temp_) &&
-              indoor_temp_ > static_cast<float>(cool_setpoint_))) {
-      this->action = climate::CLIMATE_ACTION_COOLING;
-    } else if (current_mode_ == MODE_HEAT ||
-             (current_mode_ == MODE_AUTO && !std::isnan(indoor_temp_) &&
-              indoor_temp_ < static_cast<float>(heat_setpoint_))) {
+  } else if (heat_stage_ > 0) {
+    this->action = climate::CLIMATE_ACTION_HEATING;
+  } else if (hp_stage_ > 0 && current_mode_ == MODE_COOL) {
+    this->action = climate::CLIMATE_ACTION_COOLING;
+  } else if (hp_stage_ > 0 && current_mode_ == MODE_AUTO) {
+    // Heat pump active in auto mode — determine direction from coil temp
+    // If coil is hotter than outdoor, it's heating; otherwise cooling
+    if (!std::isnan(hp_coil_temp_) && !std::isnan(outdoor_temp_) &&
+        hp_coil_temp_ > outdoor_temp_ + 10.0f) {
       this->action = climate::CLIMATE_ACTION_HEATING;
     } else {
-      this->action = climate::CLIMATE_ACTION_FAN;
+      this->action = climate::CLIMATE_ACTION_COOLING;
     }
+  } else if (hp_stage_ > 0 && current_mode_ == MODE_HEAT) {
+    this->action = climate::CLIMATE_ACTION_HEATING;
+  } else if (blower_running_) {
+    this->action = climate::CLIMATE_ACTION_FAN;
   } else {
     this->action = climate::CLIMATE_ACTION_IDLE;
   }
@@ -804,32 +810,41 @@ void AbcdEspComponent::publish_climate_state() {
 // Publish sensor entities
 // ==========================================================================
 void AbcdEspComponent::publish_sensors() {
-  if (outdoor_temp_sensor_ != nullptr && !std::isnan(outdoor_temp_)) {
+  if (outdoor_temp_sensor_ != nullptr && !std::isnan(outdoor_temp_) &&
+      (std::isnan(prev_outdoor_temp_) || outdoor_temp_ != prev_outdoor_temp_)) {
     outdoor_temp_sensor_->publish_state(outdoor_temp_);
+    prev_outdoor_temp_ = outdoor_temp_;
   }
 
-  if (airflow_cfm_sensor_ != nullptr) {
+  if (airflow_cfm_sensor_ != nullptr && airflow_cfm_ != prev_airflow_cfm_) {
     airflow_cfm_sensor_->publish_state(static_cast<float>(airflow_cfm_));
+    prev_airflow_cfm_ = airflow_cfm_;
   }
 
-  if (blower_sensor_ != nullptr) {
+  if (blower_sensor_ != nullptr && blower_running_ != prev_blower_running_) {
     blower_sensor_->publish_state(blower_running_);
+    prev_blower_running_ = blower_running_;
   }
 
-  if (heat_stage_sensor_ != nullptr) {
+  if (heat_stage_sensor_ != nullptr && heat_stage_ != prev_heat_stage_) {
     heat_stage_sensor_->publish_state(static_cast<float>(heat_stage_));
+    prev_heat_stage_ = heat_stage_;
   }
 
-  if (indoor_humidity_sensor_ != nullptr) {
+  if (indoor_humidity_sensor_ != nullptr && indoor_humidity_ != prev_indoor_humidity_) {
     indoor_humidity_sensor_->publish_state(static_cast<float>(indoor_humidity_));
+    prev_indoor_humidity_ = indoor_humidity_;
   }
 
-  if (hp_coil_temp_sensor_ != nullptr && !std::isnan(hp_coil_temp_)) {
+  if (hp_coil_temp_sensor_ != nullptr && !std::isnan(hp_coil_temp_) &&
+      (std::isnan(prev_hp_coil_temp_) || hp_coil_temp_ != prev_hp_coil_temp_)) {
     hp_coil_temp_sensor_->publish_state(hp_coil_temp_);
+    prev_hp_coil_temp_ = hp_coil_temp_;
   }
 
-  if (hp_stage_sensor_ != nullptr) {
+  if (hp_stage_sensor_ != nullptr && hp_stage_ != prev_hp_stage_) {
     hp_stage_sensor_->publish_state(static_cast<float>(hp_stage_));
+    prev_hp_stage_ = hp_stage_;
   }
 }
 
@@ -852,6 +867,11 @@ void AbcdEspComponent::dump_config() {
   LOG_SENSOR("  ", "HP Coil Temp", hp_coil_temp_sensor_);
   LOG_SENSOR("  ", "HP Stage", hp_stage_sensor_);
   LOG_BINARY_SENSOR("  ", "Comms OK", comms_ok_sensor_);
+  if (allow_control_switch_ != nullptr) {
+    ESP_LOGCONFIG(TAG, "  Allow Control Switch: configured");
+  } else {
+    ESP_LOGCONFIG(TAG, "  Allow Control Switch: not configured (read-only)");
+  }
 }
 
 }  // namespace abcdesp

--- a/components/abcdesp/abcdesp.h
+++ b/components/abcdesp/abcdesp.h
@@ -184,6 +184,15 @@ class AbcdEspComponent : public Component,
   float hp_coil_temp_{NAN};
   uint8_t hp_stage_{0};
 
+  // Previous sensor values for deduplication
+  float prev_outdoor_temp_{NAN};
+  uint16_t prev_airflow_cfm_{UINT16_MAX};
+  bool prev_blower_running_{false};
+  uint8_t prev_heat_stage_{UINT8_MAX};
+  uint8_t prev_indoor_humidity_{UINT8_MAX};
+  float prev_hp_coil_temp_{NAN};
+  uint8_t prev_hp_stage_{UINT8_MAX};
+
   // Sensor pointers
   sensor::Sensor *outdoor_temp_sensor_{nullptr};
   sensor::Sensor *airflow_cfm_sensor_{nullptr};


### PR DESCRIPTION
## Summary

Zero-protocol-risk improvements to how the component presents itself to Home Assistant users.

## Changes

### Climate entity
- **Current humidity** — set `this->current_humidity` in `publish_climate_state()` so humidity displays directly on the HA climate card without needing a separate sensor
- **Action logic** — use real `heat_stage_` / `hp_stage_` data from the air handler and heat pump to determine heating/cooling/fan action, instead of guessing by comparing indoor temp to setpoints

### Sensor deduplication
- Only call `publish_state()` on each sensor when its value actually changes, reducing unnecessary HA recorder writes and websocket traffic
- Track previous values for all 7 sensors (outdoor temp, CFM, blower, heat stage, humidity, HP coil temp, HP stage)

### dump_config
- Log whether the Allow Control switch is configured (helps with ESPHome debug logs)

### Documentation
- **README**: note that HA auto-converts °F sensor values to the user's configured unit system
- **README**: mention humidity in the climate entity description
- **TODO**: add planned items for single/dual setpoint, fan-only mode, presets, switch internalization, bus detection