### PR TITLE
Single/dual setpoint by mode, document fan-only limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ impersonating a SAM (System Access Module).
 
 | Entity | Type | Description |
 |--------|------|-------------|
-| HVAC | Climate | Mode (off/heat/cool/auto), fan (auto/low/med/high), heat+cool setpoints, current temperature and humidity |
+| HVAC | Climate | Mode (off/heat/cool/auto), fan (auto/low/med/high), setpoints, current temperature and humidity |
 | Allow Control | Switch | Enables HVAC control from HA (default: OFF — see [Read-Only Mode](#read-only-mode)) |
 | Outdoor Temperature | Sensor | Outdoor air temp in °F (from heat pump 3E01 if available, otherwise from thermostat 3B02) |
 | Indoor Humidity | Sensor | Indoor relative humidity (%) from thermostat |

--- a/TODO.md
+++ b/TODO.md
@@ -30,8 +30,8 @@ _(All planned sensors have been implemented.)_
 ## Entity Improvements
 
 - **Heat stage labels** — map raw heat stage values (0–3) to meaningful labels (off/low/med/high) via a text sensor or HA template
-- **Single vs. dual setpoint by mode** — show one target temperature in heat/cool mode, two in auto
-- **Fan-only mode** — expose fan-only operation via the climate entity
+- ~~**Single vs. dual setpoint by mode**~~ — done: single slider in heat/cool, dual in auto
+- ~~**Fan-only mode**~~ — not supported by the Carrier Infinity protocol (no fan-only mode byte exists; modes are: heat, cool, auto, electric, heatpump_only, off)
 - **Away/vacation preset** — map Carrier vacation hold to HA climate presets
 - **Internalize Allow Control switch** — register the switch inside the component instead of requiring a separate `switch:` block in YAML
 

--- a/components/abcdesp/abcdesp.cpp
+++ b/components/abcdesp/abcdesp.cpp
@@ -570,7 +570,7 @@ void AbcdEspComponent::parse_heatpump_02(const uint8_t *data,
 climate::ClimateTraits AbcdEspComponent::traits() {
   auto traits = climate::ClimateTraits();
   traits.add_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE |
-                           climate::CLIMATE_REQUIRES_TWO_POINT_TARGET_TEMPERATURE);
+                           climate::CLIMATE_SUPPORTS_TWO_POINT_TARGET_TEMPERATURE);
   traits.set_visual_min_temperature(f_to_c(40));   // 40°F ≈ 4.4°C
   traits.set_visual_max_temperature(f_to_c(99));   // 99°F ≈ 37.2°C
   traits.set_visual_target_temperature_step(0.5);   // 0.5°C step, rounds to nearest °F
@@ -662,6 +662,21 @@ void AbcdEspComponent::control(const climate::ClimateCall &call) {
     flags |= 0x0001;  // fan mode flag
   }
 
+  // Single target temperature (heat or cool mode)
+  if (call.get_target_temperature().has_value()) {
+    uint8_t target = static_cast<uint8_t>(c_to_f(*call.get_target_temperature()) + 0.5f);
+    // Determine which setpoint based on effective mode
+    uint8_t effective_mode = call.get_mode().has_value() ? new_mode : current_mode_;
+    if (effective_mode == MODE_HEAT) {
+      new_heat = target;
+      flags |= 0x0004;  // heat setpoint flag
+    } else if (effective_mode == MODE_COOL) {
+      new_cool = target;
+      flags |= 0x0008;  // cool setpoint flag
+    }
+  }
+
+  // Dual target temperatures (auto/heat_cool mode)
   if (call.get_target_temperature_low().has_value()) {
     new_heat = static_cast<uint8_t>(c_to_f(*call.get_target_temperature_low()) + 0.5f);
     flags |= 0x0004;  // heat setpoint flag
@@ -741,10 +756,6 @@ void AbcdEspComponent::publish_climate_state() {
   // Current humidity
   this->current_humidity = static_cast<float>(indoor_humidity_);
 
-  // Target temperatures (convert °F → °C for HA)
-  this->target_temperature_low = f_to_c(static_cast<float>(heat_setpoint_));
-  this->target_temperature_high = f_to_c(static_cast<float>(cool_setpoint_));
-
   // Mode
   switch (current_mode_) {
     case MODE_HEAT:
@@ -759,6 +770,23 @@ void AbcdEspComponent::publish_climate_state() {
     case MODE_OFF:
     default:
       this->mode = climate::CLIMATE_MODE_OFF;
+      break;
+  }
+
+  // Target temperatures (convert °F → °C for HA)
+  // Use single target in heat/cool modes, dual target in auto mode
+  switch (this->mode) {
+    case climate::CLIMATE_MODE_HEAT:
+      this->target_temperature = f_to_c(static_cast<float>(heat_setpoint_));
+      break;
+    case climate::CLIMATE_MODE_COOL:
+      this->target_temperature = f_to_c(static_cast<float>(cool_setpoint_));
+      break;
+    case climate::CLIMATE_MODE_HEAT_COOL:
+      this->target_temperature_low = f_to_c(static_cast<float>(heat_setpoint_));
+      this->target_temperature_high = f_to_c(static_cast<float>(cool_setpoint_));
+      break;
+    default:
       break;
   }
 


### PR DESCRIPTION
## Summary

Changes how setpoints are presented in Home Assistant based on the active HVAC mode, matching how most HA climate integrations behave. Also documents why fan-only mode can't be added.

## Changes

### Single vs. dual setpoint by mode
- Changed climate trait from `CLIMATE_REQUIRES_TWO_POINT_TARGET_TEMPERATURE` to `CLIMATE_SUPPORTS_TWO_POINT_TARGET_TEMPERATURE`
- **Heat mode**: single target temperature slider controlling the heat setpoint
- **Cool mode**: single target temperature slider controlling the cool setpoint
- **Auto mode**: dual sliders for both heat and cool setpoints (unchanged behavior)
- Added `get_target_temperature()` handling in `control()` for single-target modes, determining which setpoint to update based on the effective mode

### Fan-only mode: not supported
The Carrier Infinity protocol does not have a fan-only mode byte. The documented mode values are:
- `0x00` = heat, `0x01` = cool, `0x02` = auto, `0x03` = electric, `0x04` = heatpump_only, `0x05` = off

(Source: [Infinitude wiki - Interpreting Data](https://github.com/nebulous/infinitude/wiki/Infinity---interpreting-data))

Fan circulation is controlled independently via the fan mode setting (auto/low/med/high). Setting the fan to low/med/high runs it continuously regardless of HVAC mode, but there is no way to run the fan without the system being in one of the above modes.

### Docs
- Updated TODO.md: marked single/dual setpoint as done, documented fan-only limitation
- Updated README.md: simplified climate entity description