### PR TITLE
Bus device detection logging and unique ID docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,3 +115,15 @@ esphome run abcdesp.yaml
 A SAM (System Access Module) is a Carrier accessory that provides remote/internet access to the HVAC system. This component pretends to be one. If you have a physical SAM installed, you must disconnect it before using this component — two devices at the same bus address will corrupt communications.
 
 Most residential systems with a standard thermostat, furnace, and heat pump do **not** have a SAM installed.
+
+## Multiple ESP32 Units
+
+If you have multiple Carrier Infinity systems (e.g. separate upstairs/downstairs units), each needs its own ESP32 + MAX485 wired to its own ABCD bus. Give each a unique `name:` in its YAML config:
+
+```yaml
+esphome:
+  name: abcdesp-upstairs    # unique per device
+  friendly_name: HVAC Upstairs
+```
+
+Each device will appear as a separate ESPHome integration in Home Assistant with its own set of entities. The `name` field determines the device's mDNS hostname and HA entity ID prefix.

--- a/TODO.md
+++ b/TODO.md
@@ -37,5 +37,5 @@ _(All planned sensors have been implemented.)_
 
 ## Other
 
-- **Bus device detection** — log which devices (thermostat, air handler, heat pump) are detected on the bus and warn about missing ones
-- **Unique ID handling** — document behavior for users with multiple ESP32 units
+- ~~**Bus device detection**~~ — done: logs which devices are detected on the bus after 60s and warns about missing ones
+- ~~**Unique ID handling**~~ — done: documented in README

--- a/components/abcdesp/abcdesp.cpp
+++ b/components/abcdesp/abcdesp.cpp
@@ -267,6 +267,24 @@ void AbcdEspComponent::loop() {
     }
   }
 
+  // --- Log bus device detection summary after startup ---
+  if (!bus_detection_logged_ && millis() > 60000) {
+    bus_detection_logged_ = true;
+    ESP_LOGI(TAG, "Bus device summary: thermostat=%s  air_handler=%s  heat_pump=%s",
+             seen_thermostat_ ? "yes" : "NO",
+             seen_air_handler_ ? "yes" : "NO",
+             seen_heat_pump_ ? "yes" : "NO");
+    if (!seen_thermostat_) {
+      ESP_LOGW(TAG, "No thermostat detected — check RS-485 wiring and baud rate");
+    }
+    if (!seen_air_handler_) {
+      ESP_LOGW(TAG, "No air handler detected — airflow/blower/heat stage sensors will not update");
+    }
+    if (!seen_heat_pump_) {
+      ESP_LOGW(TAG, "No heat pump detected — HP sensors will not update (normal if system has no heat pump)");
+    }
+  }
+
   // --- Periodic polling of thermostat ---
   uint32_t now = millis();
   if (!awaiting_response_ && !write_pending_ &&
@@ -336,8 +354,17 @@ void AbcdEspComponent::handle_frame(const InfinityFrame &frame) {
   // --- Snoop: ACK06 responses from air handler or heat pump ---
   if (frame.func == FUNC_ACK06 && frame.length > 3) {
     uint16_t src_class = frame.src & 0xFF00;
-    if (src_class == 0x4000 || src_class == 0x4200 ||
-        src_class == 0x5000 || src_class == 0x5100 || src_class == 0x5200) {
+    if (src_class == 0x4000 || src_class == 0x4200) {
+      if (!seen_air_handler_) {
+        seen_air_handler_ = true;
+        ESP_LOGI(TAG, "Detected air handler on bus (0x%04X)", frame.src);
+      }
+      handle_snooped_response(frame);
+    } else if (src_class == 0x5000 || src_class == 0x5100 || src_class == 0x5200) {
+      if (!seen_heat_pump_) {
+        seen_heat_pump_ = true;
+        ESP_LOGI(TAG, "Detected heat pump on bus (0x%04X)", frame.src);
+      }
       handle_snooped_response(frame);
     }
   }
@@ -356,6 +383,12 @@ void AbcdEspComponent::handle_ack_response(const InfinityFrame &frame) {
     if (comms_ok_sensor_ != nullptr) {
       comms_ok_sensor_->publish_state(true);
     }
+  }
+
+  // Track thermostat detection
+  if (!seen_thermostat_) {
+    seen_thermostat_ = true;
+    ESP_LOGI(TAG, "Detected thermostat on bus (0x%04X)", frame.src);
   }
 
   if (frame.length <= 3) {

--- a/components/abcdesp/abcdesp.h
+++ b/components/abcdesp/abcdesp.h
@@ -158,6 +158,12 @@ class AbcdEspComponent : public Component,
   uint32_t last_successful_response_ms_{0};
   bool comms_ok_{false};
 
+  // Bus device detection
+  bool seen_thermostat_{false};
+  bool seen_air_handler_{false};
+  bool seen_heat_pump_{false};
+  bool bus_detection_logged_{false};
+
   // Pending write
   bool write_pending_{false};
   uint8_t write_buf_[160];


### PR DESCRIPTION
## Summary

Operational quality-of-life improvements: bus device detection logging and documentation for multi-device setups. No protocol changes.

## Changes

### Bus device detection
- Track which device classes have been seen on the bus: thermostat (0x20xx), air handler (0x40xx/0x42xx), heat pump (0x50xx/0x51xx/0x52xx)
- Log each device on first detection with its address (e.g. "Detected air handler on bus (0x4001)")
- After 60 seconds, log a summary showing which devices were found and which are missing
- Warnings for missing devices:
  - **No thermostat**: likely a wiring or baud rate issue
  - **No air handler**: airflow/blower/heat stage sensors won't update
  - **No heat pump**: HP sensors won't update (noted as normal for systems without a heat pump)

### Multiple ESP32 units documentation
- Added "Multiple ESP32 Units" section to README explaining how to configure multiple devices with unique `name:` values for separate HVAC systems

### TODO
- Marked bus detection and unique ID items as completed