### PR TITLE
Hold management: clear hold button, hold sensor, deferred updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ impersonating a SAM (System Access Module).
 | HP Coil Temperature | Sensor | Heat pump coil temperature in °F |
 | HP Stage | Sensor | Heat pump compressor stage |
 | Communication OK | Binary Sensor | Whether the ESP32 is receiving responses from the thermostat (goes offline after 30s of no response) |
+| Hold Active | Binary Sensor | Whether zone 1 is in hold mode (schedule overridden) |
+| Clear Hold | Button | Clears hold on zone 1, resuming the thermostat's built-in schedule (requires Allow Control ON) |
 
 > **Note:** Only **Zone 1** is currently supported. Multi-zone systems will only see data for the first zone. See [TODO.md](TODO.md) for planned multi-zone support.
 
@@ -78,7 +80,11 @@ To enable control, toggle the **Allow Control** switch in Home Assistant. The sw
 
 ## Hold Behavior
 
-When you change setpoints from Home Assistant, the component places the thermostat into **hold** mode. This means the thermostat's built-in schedule is overridden until the hold is cleared at the thermostat itself. This is a known limitation — see [TODO.md](TODO.md) for planned improvements.
+When you change setpoints from Home Assistant, the component places the thermostat into **hold** mode. This means the thermostat's built-in schedule is overridden until the hold is cleared.
+
+To resume the thermostat's schedule, press the **Clear Hold** button in Home Assistant (requires the Allow Control switch to be ON). You can also clear the hold at the thermostat itself.
+
+The **Hold Active** binary sensor shows whether zone 1 is currently in hold mode.
 
 ## Installation
 

--- a/TODO.md
+++ b/TODO.md
@@ -11,17 +11,17 @@ Currently only Zone 1 is read and controlled. The Carrier Infinity protocol supp
 
 ## Hold / Schedule Behavior
 
-When setpoints are changed from Home Assistant, the component currently forces the thermostat into permanent **hold** mode, overriding the built-in schedule indefinitely.
+When setpoints are changed from Home Assistant, the component places the thermostat into permanent **hold** mode, overriding the built-in schedule.
 
-The physical thermostat behaves differently:
-- Pressing temp up/down sets a **2-hour temporary hold** (adjustable at the thermostat)
-- Changing mode (heat/cool/auto/off) does **not** trigger a hold
+### Done
+- ~~Clear hold from HA~~ — Clear Hold button entity sends 3B03 write clearing the hold flag
+- ~~Hold status sensor~~ — Hold Active binary sensor shows whether zone 1 is in hold
+- ~~Write feedback~~ — state updates are no longer optimistic; the next poll confirms the thermostat accepted changes
+- Mode and fan changes no longer set hold (only setpoint changes trigger hold)
 
-### Planned work
+### Remaining work
 - Implement temporary hold with a configurable duration (default 2 hours) for setpoint changes
-- Do not set hold when only changing mode or fan speed
-- Provide a way to **clear hold** from Home Assistant, resuming the thermostat's built-in schedule
-- Consider exposing a "Hold Status" sensor showing whether the system is in hold, and what type
+- Consider supporting timed override via the 3B03 override fields (bytes 37-53)
 
 ## Additional Sensors
 

--- a/abcdesp.yaml
+++ b/abcdesp.yaml
@@ -76,3 +76,7 @@ abcdesp:
     name: "Blower Running"
   comms_ok_sensor:
     name: "Communication OK"
+  hold_active_sensor:
+    name: "Hold Active"
+  clear_hold_button:
+    name: "Clear Hold"

--- a/components/abcdesp/__init__.py
+++ b/components/abcdesp/__init__.py
@@ -1,6 +1,6 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.components import climate, sensor, binary_sensor, switch, uart
+from esphome.components import climate, sensor, binary_sensor, switch, button, uart
 from esphome.const import (
     DEVICE_CLASS_HUMIDITY,
     DEVICE_CLASS_TEMPERATURE,
@@ -14,12 +14,13 @@ from esphome.const import (
 from esphome import pins
 
 DEPENDENCIES = ["uart"]
-AUTO_LOAD = ["climate", "sensor", "binary_sensor"]
+AUTO_LOAD = ["climate", "sensor", "binary_sensor", "button"]
 
 abcdesp_ns = cg.esphome_ns.namespace("abcdesp")
 AbcdEspComponent = abcdesp_ns.class_(
     "AbcdEspComponent", cg.Component, climate.Climate, uart.UARTDevice
 )
+ClearHoldButton = abcdesp_ns.class_("ClearHoldButton", button.Button)
 
 CONF_FLOW_PIN = "flow_pin"
 CONF_OUTDOOR_TEMP_SENSOR = "outdoor_temp_sensor"
@@ -31,6 +32,8 @@ CONF_INDOOR_HUMIDITY_SENSOR = "indoor_humidity_sensor"
 CONF_HP_COIL_TEMP_SENSOR = "hp_coil_temp_sensor"
 CONF_HP_STAGE_SENSOR = "hp_stage_sensor"
 CONF_COMMS_OK_SENSOR = "comms_ok_sensor"
+CONF_HOLD_ACTIVE_SENSOR = "hold_active_sensor"
+CONF_CLEAR_HOLD_BUTTON = "clear_hold_button"
 
 CONFIG_SCHEMA = (
     climate.climate_schema(AbcdEspComponent)
@@ -82,6 +85,13 @@ CONFIG_SCHEMA = (
                 device_class=DEVICE_CLASS_CONNECTIVITY,
                 entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
             ),
+            cv.Optional(CONF_HOLD_ACTIVE_SENSOR): binary_sensor.binary_sensor_schema(
+                icon="mdi:hand-back-left",
+            ),
+            cv.Optional(CONF_CLEAR_HOLD_BUTTON): button.button_schema(
+                ClearHoldButton,
+                icon="mdi:hand-back-left-off",
+            ),
             cv.Optional(CONF_ALLOW_CONTROL_SWITCH): cv.use_id(switch.Switch),
         }
     )
@@ -128,6 +138,15 @@ async def to_code(config):
     if CONF_COMMS_OK_SENSOR in config:
         sens = await binary_sensor.new_binary_sensor(config[CONF_COMMS_OK_SENSOR])
         cg.add(var.set_comms_ok_sensor(sens))
+
+    if CONF_HOLD_ACTIVE_SENSOR in config:
+        sens = await binary_sensor.new_binary_sensor(config[CONF_HOLD_ACTIVE_SENSOR])
+        cg.add(var.set_hold_active_sensor(sens))
+
+    if CONF_CLEAR_HOLD_BUTTON in config:
+        btn = await button.new_button(config[CONF_CLEAR_HOLD_BUTTON])
+        cg.add(btn.set_parent(var))
+        cg.add(var.set_clear_hold_button(btn))
 
     if CONF_ALLOW_CONTROL_SWITCH in config:
         sw = await cg.get_variable(config[CONF_ALLOW_CONTROL_SWITCH])

--- a/components/abcdesp/abcdesp.cpp
+++ b/components/abcdesp/abcdesp.cpp
@@ -9,6 +9,15 @@ namespace abcdesp {
 static const char *const TAG = "abcdesp";
 
 // ==========================================================================
+// ClearHoldButton — press_action calls parent clear_hold()
+// ==========================================================================
+void ClearHoldButton::press_action() {
+  if (parent_ != nullptr) {
+    parent_->clear_hold();
+  }
+}
+
+// ==========================================================================
 // Temperature unit conversion helpers
 // ==========================================================================
 static float f_to_c(float f) { return (f - 32.0f) * 5.0f / 9.0f; }
@@ -332,7 +341,8 @@ void AbcdEspComponent::handle_frame(const InfinityFrame &frame) {
 
   // --- NAK to our request ---
   if (frame.func == FUNC_NAK && frame.dst == ADDR_SAM) {
-    ESP_LOGW(TAG, "NAK received from 0x%04X", frame.src);
+    ESP_LOGW(TAG, "NAK received from 0x%04X for pending 0x%02X%02X — command rejected by thermostat",
+             frame.src, pending_table_, pending_row_);
     awaiting_response_ = false;
     return;
   }
@@ -508,6 +518,15 @@ void AbcdEspComponent::parse_tstat_zones(const uint8_t *data,
 
   ESP_LOGD(TAG, "3B03: fan=%d  hold=0x%02X  heat=%d  cool=%d",
            fan_mode_, zone_hold_, heat_setpoint_, cool_setpoint_);
+
+  // Publish hold status
+  bool hold_active = (zone_hold_ & 0x01) != 0;
+  if (hold_active_sensor_ != nullptr &&
+      (!hold_active_initialized_ || hold_active != prev_hold_active_)) {
+    hold_active_sensor_->publish_state(hold_active);
+    prev_hold_active_ = hold_active;
+    hold_active_initialized_ = true;
+  }
 
   publish_climate_state();
 }
@@ -730,8 +749,8 @@ void AbcdEspComponent::control(const climate::ClimateCall &call) {
     mode_buf[22] = new_mode;
     send_write_request(ADDR_TSTAT, TBL_SAM_INFO, ROW_SAM_STATE,
                        mode_buf, 29);
-    current_mode_ = new_mode;
     ESP_LOGI(TAG, "Setting mode to %d", new_mode);
+    // Note: current_mode_ is NOT updated here. The next poll will confirm.
   }
 
   // Send 3B03 if any zone settings changed
@@ -745,9 +764,12 @@ void AbcdEspComponent::control(const climate::ClimateCall &call) {
       write_buf_[3 + i] = FAN_AUTO;
     }
 
-    // Hold flag (offset 11) — set hold for zone 1
-    write_buf_[11] = 0x01;
-    flags |= 0x0002;
+    // Hold flag (offset 11) — only set hold when setpoints changed
+    bool setpoints_changed = (flags & 0x000C) != 0;  // heat or cool setpoint flags
+    if (setpoints_changed) {
+      write_buf_[11] = 0x01;
+      flags |= 0x0002;
+    }
     write_buf_[1] = (flags >> 8) & 0xFF;
     write_buf_[2] = flags & 0xFF;
 
@@ -766,15 +788,12 @@ void AbcdEspComponent::control(const climate::ClimateCall &call) {
     write_len_ = 28;
     write_pending_ = true;
 
-    fan_mode_ = new_fan;
-    heat_setpoint_ = new_heat;
-    cool_setpoint_ = new_cool;
-
     ESP_LOGI(TAG, "Queued 3B03 write: fan=%d heat=%d cool=%d", new_fan,
              new_heat, new_cool);
   }
 
-  publish_climate_state();
+  // Note: state is NOT optimistically updated here.
+  // The next poll of 3B02/3B03 will confirm the thermostat accepted the change.
 }
 
 // ==========================================================================
@@ -928,11 +947,38 @@ void AbcdEspComponent::dump_config() {
   LOG_SENSOR("  ", "HP Coil Temp", hp_coil_temp_sensor_);
   LOG_SENSOR("  ", "HP Stage", hp_stage_sensor_);
   LOG_BINARY_SENSOR("  ", "Comms OK", comms_ok_sensor_);
+  LOG_BINARY_SENSOR("  ", "Hold Active", hold_active_sensor_);
+  if (clear_hold_button_ != nullptr) {
+    ESP_LOGCONFIG(TAG, "  Clear Hold Button: configured");
+  }
   if (allow_control_switch_ != nullptr) {
     ESP_LOGCONFIG(TAG, "  Allow Control Switch: configured");
   } else {
     ESP_LOGCONFIG(TAG, "  Allow Control Switch: not configured (read-only)");
   }
+}
+
+// ==========================================================================
+// Clear hold — send 3B03 write clearing the hold flag for zone 1
+// ==========================================================================
+void AbcdEspComponent::clear_hold() {
+  if (allow_control_switch_ == nullptr || !allow_control_switch_->state) {
+    ESP_LOGW(TAG, "Clear hold blocked: Allow Control switch is OFF");
+    return;
+  }
+
+  memset(write_buf_, 0, sizeof(write_buf_));
+  write_buf_[0] = 0x01;   // zone bitmap: zone 1
+  // flags = 0x0002 (hold flag only)
+  write_buf_[1] = 0x00;
+  write_buf_[2] = 0x02;
+  // hold bitmap (offset 11) = 0x00 — clear hold for zone 1
+  write_buf_[11] = 0x00;
+
+  write_len_ = 28;
+  write_pending_ = true;
+
+  ESP_LOGI(TAG, "Queued clear hold for zone 1");
 }
 
 }  // namespace abcdesp

--- a/components/abcdesp/abcdesp.h
+++ b/components/abcdesp/abcdesp.h
@@ -5,6 +5,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #include "esphome/components/switch/switch.h"
+#include "esphome/components/button/button.h"
 #include "esphome/components/uart/uart.h"
 
 namespace esphome {
@@ -83,6 +84,23 @@ struct InfinityFrame {
 };
 
 // ---------------------------------------------------------------------------
+// Forward declaration
+// ---------------------------------------------------------------------------
+class AbcdEspComponent;
+
+// ---------------------------------------------------------------------------
+// Clear Hold button — calls back into the main component
+// ---------------------------------------------------------------------------
+class ClearHoldButton : public button::Button {
+ public:
+  void set_parent(AbcdEspComponent *parent) { parent_ = parent; }
+
+ protected:
+  void press_action() override;
+  AbcdEspComponent *parent_{nullptr};
+};
+
+// ---------------------------------------------------------------------------
 // Main Component
 // ---------------------------------------------------------------------------
 class AbcdEspComponent : public Component,
@@ -99,6 +117,11 @@ class AbcdEspComponent : public Component,
   void set_hp_coil_temp_sensor(sensor::Sensor *s) { hp_coil_temp_sensor_ = s; }
   void set_hp_stage_sensor(sensor::Sensor *s) { hp_stage_sensor_ = s; }
   void set_comms_ok_sensor(binary_sensor::BinarySensor *s) { comms_ok_sensor_ = s; }
+  void set_hold_active_sensor(binary_sensor::BinarySensor *s) { hold_active_sensor_ = s; }
+  void set_clear_hold_button(ClearHoldButton *b) { clear_hold_button_ = b; }
+
+  // Clear hold — sends a 3B03 write clearing the hold flag
+  void clear_hold();
 
   // Component overrides
   void setup() override;
@@ -213,6 +236,14 @@ class AbcdEspComponent : public Component,
 
   // Communication health
   binary_sensor::BinarySensor *comms_ok_sensor_{nullptr};
+
+  // Hold status
+  binary_sensor::BinarySensor *hold_active_sensor_{nullptr};
+  bool prev_hold_active_{false};
+  bool hold_active_initialized_{false};
+
+  // Clear hold button
+  ClearHoldButton *clear_hold_button_{nullptr};
 
   // Publish helpers
   void publish_climate_state();


### PR DESCRIPTION
## Summary

Hold management and write reliability improvements. This PR touches protocol writes but uses the same existing 3B03 write path.

## Changes

### New entities
- **Hold Active** (binary sensor) — shows whether zone 1 is in hold mode (schedule overridden). Published from the `zone_hold_` field in 3B03, with deduplication.
- **Clear Hold** (button) — sends a 3B03 write with the hold flag cleared, resuming the thermostat's built-in schedule. Respects the Allow Control switch gate.

### Deferred optimistic updates
Previously, `control()` optimistically updated `fan_mode_`, `heat_setpoint_`, `cool_setpoint_`, and `current_mode_` before the write was even sent. If the thermostat NAK'd the write, the HA entity would show the wrong state until the next poll.

Now, `control()` only queues the write. The cached state is updated when the next poll of 3B02/3B03 returns the confirmed values from the thermostat. If a write fails, the state naturally stays unchanged.

### Hold flag only on setpoint changes
The 3B03 hold flag is now only set when setpoints are changed — mode and fan mode changes no longer trigger hold. This matches the physical thermostat's behavior.

### Improved NAK logging
NAK messages now include the pending register address, making it easier to diagnose which command was rejected.

### Documentation
- README: updated Hold Behavior section with clear hold instructions
- TODO: marked hold items as done, noted remaining timed-override work
- YAML: added hold_active_sensor and clear_hold_button examples