### PR TITLE
feat: heat stage text sensor, internalize Allow Control switch, away/vacation preset

### DIFF
--- a/abcdesp.yaml
+++ b/abcdesp.yaml
@@ -43,14 +43,6 @@ uart:
   stop_bits: 1
   parity: NONE
 
-switch:
-  - platform: template
-    name: "Allow Control"
-    id: allow_control
-    optimistic: true
-    restore_mode: RESTORE_DEFAULT_OFF
-    icon: "mdi:lock-open-variant"
-
 abcdesp:
   name: "HVAC"
   icon: "mdi:hvac"
@@ -59,7 +51,8 @@ abcdesp:
     number: GPIO4
     mode:
       output: true
-  allow_control_switch: allow_control
+  allow_control_switch:
+    name: "Allow Control"
   outdoor_temp_sensor:
     name: "Outdoor Temperature"
   indoor_humidity_sensor:
@@ -68,6 +61,8 @@ abcdesp:
     name: "Airflow CFM"
   heat_stage_sensor:
     name: "Heat Stage"
+  heat_stage_text_sensor:
+    name: "Heat Stage Label"
   hp_coil_temp_sensor:
     name: "HP Coil Temperature"
   hp_stage_sensor:

--- a/components/abcdesp/__init__.py
+++ b/components/abcdesp/__init__.py
@@ -1,6 +1,6 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.components import climate, sensor, binary_sensor, switch, button, uart
+from esphome.components import climate, sensor, text_sensor, binary_sensor, switch, button, uart
 from esphome.const import (
     DEVICE_CLASS_HUMIDITY,
     DEVICE_CLASS_TEMPERATURE,
@@ -14,19 +14,21 @@ from esphome.const import (
 from esphome import pins
 
 DEPENDENCIES = ["uart"]
-AUTO_LOAD = ["climate", "sensor", "binary_sensor", "button"]
+AUTO_LOAD = ["climate", "sensor", "text_sensor", "binary_sensor", "switch", "button"]
 
 abcdesp_ns = cg.esphome_ns.namespace("abcdesp")
 AbcdEspComponent = abcdesp_ns.class_(
     "AbcdEspComponent", cg.Component, climate.Climate, uart.UARTDevice
 )
 ClearHoldButton = abcdesp_ns.class_("ClearHoldButton", button.Button)
+AllowControlSwitch = abcdesp_ns.class_("AllowControlSwitch", switch.Switch)
 
 CONF_FLOW_PIN = "flow_pin"
 CONF_OUTDOOR_TEMP_SENSOR = "outdoor_temp_sensor"
 CONF_AIRFLOW_CFM_SENSOR = "airflow_cfm_sensor"
 CONF_BLOWER_SENSOR = "blower_sensor"
 CONF_HEAT_STAGE_SENSOR = "heat_stage_sensor"
+CONF_HEAT_STAGE_TEXT_SENSOR = "heat_stage_text_sensor"
 CONF_ALLOW_CONTROL_SWITCH = "allow_control_switch"
 CONF_INDOOR_HUMIDITY_SENSOR = "indoor_humidity_sensor"
 CONF_HP_COIL_TEMP_SENSOR = "hp_coil_temp_sensor"
@@ -65,6 +67,10 @@ CONFIG_SCHEMA = (
                 state_class=STATE_CLASS_MEASUREMENT,
                 entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
             ),
+            cv.Optional(CONF_HEAT_STAGE_TEXT_SENSOR): text_sensor.text_sensor_schema(
+                icon="mdi:fire",
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+            ),
             cv.Optional(CONF_HP_COIL_TEMP_SENSOR): sensor.sensor_schema(
                 unit_of_measurement="°F",
                 accuracy_decimals=1,
@@ -92,7 +98,10 @@ CONFIG_SCHEMA = (
                 ClearHoldButton,
                 icon="mdi:hand-back-left-off",
             ),
-            cv.Optional(CONF_ALLOW_CONTROL_SWITCH): cv.use_id(switch.Switch),
+            cv.Optional(CONF_ALLOW_CONTROL_SWITCH): switch.switch_schema(
+                AllowControlSwitch,
+                icon="mdi:lock-open-variant",
+            ),
         }
     )
     .extend(uart.UART_DEVICE_SCHEMA)
@@ -123,6 +132,10 @@ async def to_code(config):
         sens = await sensor.new_sensor(config[CONF_HEAT_STAGE_SENSOR])
         cg.add(var.set_heat_stage_sensor(sens))
 
+    if CONF_HEAT_STAGE_TEXT_SENSOR in config:
+        sens = await text_sensor.new_text_sensor(config[CONF_HEAT_STAGE_TEXT_SENSOR])
+        cg.add(var.set_heat_stage_text_sensor(sens))
+
     if CONF_HP_COIL_TEMP_SENSOR in config:
         sens = await sensor.new_sensor(config[CONF_HP_COIL_TEMP_SENSOR])
         cg.add(var.set_hp_coil_temp_sensor(sens))
@@ -149,5 +162,5 @@ async def to_code(config):
         cg.add(var.set_clear_hold_button(btn))
 
     if CONF_ALLOW_CONTROL_SWITCH in config:
-        sw = await cg.get_variable(config[CONF_ALLOW_CONTROL_SWITCH])
+        sw = await switch.new_switch(config[CONF_ALLOW_CONTROL_SWITCH])
         cg.add(var.set_allow_control_switch(sw))

--- a/components/abcdesp/abcdesp.cpp
+++ b/components/abcdesp/abcdesp.cpp
@@ -213,6 +213,10 @@ void AbcdEspComponent::setup() {
     flow_pin_->setup();
     flow_pin_->digital_write(false);  // start in RX mode
   }
+  // Initialize Allow Control switch to OFF (control blocked until user enables)
+  if (allow_control_switch_ != nullptr) {
+    allow_control_switch_->publish_state(false);
+  }
   rx_len_ = 0;
   last_poll_ms_ = millis();
   poll_step_ = 0;
@@ -312,7 +316,7 @@ void AbcdEspComponent::loop() {
 }
 
 // ==========================================================================
-// Poll thermostat — alternate between 3B02 and 3B03
+// Poll thermostat — cycle through 3B02, 3B03, 3B04
 // ==========================================================================
 void AbcdEspComponent::poll_thermostat() {
   switch (poll_step_) {
@@ -322,8 +326,11 @@ void AbcdEspComponent::poll_thermostat() {
     case 1:
       send_read_request(ADDR_TSTAT, TBL_SAM_INFO, ROW_SAM_ZONES);
       break;
+    case 2:
+      send_read_request(ADDR_TSTAT, TBL_SAM_INFO, ROW_SAM_VACATION);
+      break;
   }
-  poll_step_ = (poll_step_ + 1) % 2;
+  poll_step_ = (poll_step_ + 1) % 3;
 }
 
 // ==========================================================================
@@ -415,6 +422,8 @@ void AbcdEspComponent::handle_ack_response(const InfinityFrame &frame) {
     parse_tstat_state(reg_data, reg_len);
   } else if (table == TBL_SAM_INFO && row == ROW_SAM_ZONES) {
     parse_tstat_zones(reg_data, reg_len);
+  } else if (table == TBL_SAM_INFO && row == ROW_SAM_VACATION) {
+    parse_vacation(reg_data, reg_len);
   }
 }
 
@@ -617,6 +626,27 @@ void AbcdEspComponent::parse_heatpump_02(const uint8_t *data,
 }
 
 // ==========================================================================
+// Parse 3B04 — vacation settings (11 bytes)
+// Layout: [0]=vacation_active, [1-2]=days*7(BE), [3]=mintemp, [4]=maxtemp,
+//         [5]=minhumidity, [6]=maxhumidity, [7]=fanmode
+// ==========================================================================
+void AbcdEspComponent::parse_vacation(const uint8_t *data, uint8_t len) {
+  if (len < 1) {
+    return;
+  }
+
+  bool was_active = vacation_active_;
+  vacation_active_ = (data[0] != 0);
+
+  ESP_LOGD(TAG, "3B04: vacation=%s", vacation_active_ ? "active" : "off");
+
+  if (!vacation_initialized_ || vacation_active_ != was_active) {
+    vacation_initialized_ = true;
+    publish_climate_state();
+  }
+}
+
+// ==========================================================================
 // Climate traits
 // ==========================================================================
 climate::ClimateTraits AbcdEspComponent::traits() {
@@ -640,6 +670,11 @@ climate::ClimateTraits AbcdEspComponent::traits() {
       climate::CLIMATE_FAN_LOW,
       climate::CLIMATE_FAN_MEDIUM,
       climate::CLIMATE_FAN_HIGH,
+  });
+
+  traits.set_supported_presets({
+      climate::CLIMATE_PRESET_HOME,
+      climate::CLIMATE_PRESET_AWAY,
   });
 
   return traits;
@@ -794,6 +829,35 @@ void AbcdEspComponent::control(const climate::ClimateCall &call) {
 
   // Note: state is NOT optimistically updated here.
   // The next poll of 3B02/3B03 will confirm the thermostat accepted the change.
+
+  // Handle preset change (vacation via 3B04)
+  if (call.get_preset().has_value()) {
+    auto preset = *call.get_preset();
+    if (preset == climate::CLIMATE_PRESET_AWAY && !vacation_active_) {
+      // Activate vacation with default settings:
+      // 7 days, min 55°F, max 85°F, 15% min humidity, 60% max humidity, fan auto
+      uint8_t vac_buf[8];
+      vac_buf[0] = 0x01;  // vacation_active = 1
+      vac_buf[1] = 0x00;  // days*7 high byte (7*7=49)
+      vac_buf[2] = 0x31;  // days*7 low byte (49)
+      vac_buf[3] = 55;    // min temp °F
+      vac_buf[4] = 85;    // max temp °F
+      vac_buf[5] = 15;    // min humidity
+      vac_buf[6] = 60;    // max humidity
+      vac_buf[7] = FAN_AUTO;
+      send_write_request(ADDR_TSTAT, TBL_SAM_INFO, ROW_SAM_VACATION,
+                         vac_buf, 8);
+      ESP_LOGI(TAG, "Activating vacation mode (7 days, 55-85F)");
+    } else if (preset == climate::CLIMATE_PRESET_HOME && vacation_active_) {
+      // Deactivate vacation
+      uint8_t vac_buf[8];
+      memset(vac_buf, 0, sizeof(vac_buf));
+      vac_buf[0] = 0x00;  // vacation_active = 0
+      send_write_request(ADDR_TSTAT, TBL_SAM_INFO, ROW_SAM_VACATION,
+                         vac_buf, 8);
+      ESP_LOGI(TAG, "Deactivating vacation mode");
+    }
+  }
 }
 
 // ==========================================================================
@@ -883,6 +947,12 @@ void AbcdEspComponent::publish_climate_state() {
     this->action = climate::CLIMATE_ACTION_IDLE;
   }
 
+  // Preset
+  if (vacation_initialized_) {
+    this->preset = vacation_active_ ? climate::CLIMATE_PRESET_AWAY
+                                    : climate::CLIMATE_PRESET_HOME;
+  }
+
   this->publish_state();
 }
 
@@ -906,8 +976,15 @@ void AbcdEspComponent::publish_sensors() {
     prev_blower_running_ = blower_running_;
   }
 
-  if (heat_stage_sensor_ != nullptr && heat_stage_ != prev_heat_stage_) {
-    heat_stage_sensor_->publish_state(static_cast<float>(heat_stage_));
+  if (heat_stage_ != prev_heat_stage_) {
+    if (heat_stage_sensor_ != nullptr) {
+      heat_stage_sensor_->publish_state(static_cast<float>(heat_stage_));
+    }
+    if (heat_stage_text_sensor_ != nullptr) {
+      static const char *const kHeatStageLabels[] = {"Off", "Low", "Med", "High"};
+      uint8_t idx = (heat_stage_ <= 3) ? heat_stage_ : 0;
+      heat_stage_text_sensor_->publish_state(kHeatStageLabels[idx]);
+    }
     prev_heat_stage_ = heat_stage_;
   }
 
@@ -943,6 +1020,7 @@ void AbcdEspComponent::dump_config() {
   LOG_SENSOR("  ", "Airflow CFM", airflow_cfm_sensor_);
   LOG_BINARY_SENSOR("  ", "Blower", blower_sensor_);
   LOG_SENSOR("  ", "Heat Stage", heat_stage_sensor_);
+  LOG_TEXT_SENSOR("  ", "Heat Stage Label", heat_stage_text_sensor_);
   LOG_SENSOR("  ", "Indoor Humidity", indoor_humidity_sensor_);
   LOG_SENSOR("  ", "HP Coil Temp", hp_coil_temp_sensor_);
   LOG_SENSOR("  ", "HP Stage", hp_stage_sensor_);

--- a/components/abcdesp/abcdesp.h
+++ b/components/abcdesp/abcdesp.h
@@ -176,7 +176,6 @@ class AbcdEspComponent : public Component,
   void parse_heatpump_01(const uint8_t *data, uint8_t len);
   void parse_heatpump_02(const uint8_t *data, uint8_t len);
   void parse_vacation(const uint8_t *data, uint8_t len);
-  void parse_vacation(const uint8_t *data, uint8_t len);
 
   // Polling
   void poll_thermostat();
@@ -214,10 +213,6 @@ class AbcdEspComponent : public Component,
   uint8_t heat_setpoint_{68};
   uint8_t cool_setpoint_{74};
   uint8_t zone_hold_{0};
-
-  // Vacation state
-  bool vacation_active_{false};
-  bool vacation_initialized_{false};
 
   // Vacation state
   bool vacation_active_{false};

--- a/components/abcdesp/abcdesp.h
+++ b/components/abcdesp/abcdesp.h
@@ -3,6 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/climate/climate.h"
 #include "esphome/components/sensor/sensor.h"
+#include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #include "esphome/components/switch/switch.h"
 #include "esphome/components/button/button.h"
@@ -37,6 +38,7 @@ static const uint8_t REG_PREFIX         = 0x00;
 static const uint8_t TBL_SAM_INFO       = 0x3B;
 static const uint8_t ROW_SAM_STATE      = 0x02;  // 3B02 — temps, mode
 static const uint8_t ROW_SAM_ZONES      = 0x03;  // 3B03 — setpoints, fan
+static const uint8_t ROW_SAM_VACATION   = 0x04;  // 3B04 — vacation settings
 static const uint8_t ROW_SAM_ACK        = 0x0E;  // 3B0E — ack from tstat
 
 static const uint8_t TBL_RLCSMAIN      = 0x03;
@@ -101,6 +103,14 @@ class ClearHoldButton : public button::Button {
 };
 
 // ---------------------------------------------------------------------------
+// Allow Control switch — optimistic toggle, defaults to OFF on boot
+// ---------------------------------------------------------------------------
+class AllowControlSwitch : public switch_::Switch {
+ protected:
+  void write_state(bool state) override { publish_state(state); }
+};
+
+// ---------------------------------------------------------------------------
 // Main Component
 // ---------------------------------------------------------------------------
 class AbcdEspComponent : public Component,
@@ -112,6 +122,7 @@ class AbcdEspComponent : public Component,
   void set_airflow_cfm_sensor(sensor::Sensor *s) { airflow_cfm_sensor_ = s; }
   void set_blower_sensor(binary_sensor::BinarySensor *s) { blower_sensor_ = s; }
   void set_heat_stage_sensor(sensor::Sensor *s) { heat_stage_sensor_ = s; }
+  void set_heat_stage_text_sensor(text_sensor::TextSensor *s) { heat_stage_text_sensor_ = s; }
   void set_allow_control_switch(switch_::Switch *sw) { allow_control_switch_ = sw; }
   void set_indoor_humidity_sensor(sensor::Sensor *s) { indoor_humidity_sensor_ = s; }
   void set_hp_coil_temp_sensor(sensor::Sensor *s) { hp_coil_temp_sensor_ = s; }
@@ -164,6 +175,8 @@ class AbcdEspComponent : public Component,
   void parse_airhandler_16(const uint8_t *data, uint8_t len);
   void parse_heatpump_01(const uint8_t *data, uint8_t len);
   void parse_heatpump_02(const uint8_t *data, uint8_t len);
+  void parse_vacation(const uint8_t *data, uint8_t len);
+  void parse_vacation(const uint8_t *data, uint8_t len);
 
   // Polling
   void poll_thermostat();
@@ -202,6 +215,14 @@ class AbcdEspComponent : public Component,
   uint8_t cool_setpoint_{74};
   uint8_t zone_hold_{0};
 
+  // Vacation state
+  bool vacation_active_{false};
+  bool vacation_initialized_{false};
+
+  // Vacation state
+  bool vacation_active_{false};
+  bool vacation_initialized_{false};
+
   // Air handler state
   uint16_t blower_rpm_{0};
   uint16_t airflow_cfm_{0};
@@ -227,6 +248,7 @@ class AbcdEspComponent : public Component,
   sensor::Sensor *airflow_cfm_sensor_{nullptr};
   binary_sensor::BinarySensor *blower_sensor_{nullptr};
   sensor::Sensor *heat_stage_sensor_{nullptr};
+  text_sensor::TextSensor *heat_stage_text_sensor_{nullptr};
   sensor::Sensor *indoor_humidity_sensor_{nullptr};
   sensor::Sensor *hp_coil_temp_sensor_{nullptr};
   sensor::Sensor *hp_stage_sensor_{nullptr};

--- a/tests/test_protocol.cpp
+++ b/tests/test_protocol.cpp
@@ -446,6 +446,59 @@ TEST(fan_mode_encoding) {
   PASS();
 }
 
+TEST(parse_vacation_3b04) {
+  printf("test_parse_vacation_3b04\n");
+  // 3B04: [0]=vacation_active, [1-2]=days*7(BE), [3]=mintemp, [4]=maxtemp,
+  //       [5]=minhumidity, [6]=maxhumidity, [7]=fanmode
+  uint8_t data[8] = {0};
+  data[0] = 0x01;  // vacation active
+  data[1] = 0x00;  // days*7 high (7 days = 49 = 0x0031)
+  data[2] = 0x31;  // days*7 low
+  data[3] = 55;    // min temp
+  data[4] = 85;    // max temp
+  data[5] = 15;    // min humidity
+  data[6] = 60;    // max humidity
+  data[7] = FAN_AUTO;
+
+  ASSERT_EQ(data[0], 1);  // vacation active
+  uint16_t days_times7 = (data[1] << 8) | data[2];
+  ASSERT_EQ(days_times7, 49);  // 7 days * 7
+  ASSERT_EQ(data[3], 55);
+  ASSERT_EQ(data[4], 85);
+  ASSERT_EQ(data[5], 15);
+  ASSERT_EQ(data[6], 60);
+  ASSERT_EQ(data[7], FAN_AUTO);
+
+  // Inactive vacation
+  data[0] = 0x00;
+  ASSERT_EQ(data[0], 0);
+  PASS();
+}
+
+TEST(heat_stage_label_mapping) {
+  printf("test_heat_stage_label_mapping\n");
+  // Verify the label mapping logic used in publish_sensors
+  static const char *const kHeatStageLabels[] = {"Off", "Low", "Med", "High"};
+
+  for (uint8_t stage = 0; stage <= 3; stage++) {
+    uint8_t idx = (stage <= 3) ? stage : 0;
+    const char *label = kHeatStageLabels[idx];
+    ASSERT_TRUE(label != nullptr);
+  }
+
+  // Verify specific mappings
+  ASSERT_EQ(strcmp(kHeatStageLabels[0], "Off"), 0);
+  ASSERT_EQ(strcmp(kHeatStageLabels[1], "Low"), 0);
+  ASSERT_EQ(strcmp(kHeatStageLabels[2], "Med"), 0);
+  ASSERT_EQ(strcmp(kHeatStageLabels[3], "High"), 0);
+
+  // Out-of-range should map to index 0 (Off)
+  uint8_t bad_stage = 5;
+  uint8_t idx = (bad_stage <= 3) ? bad_stage : 0;
+  ASSERT_EQ(idx, 0);
+  PASS();
+}
+
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## PR 5: Presets & Component Ownership

### Heat Stage Text Sensor
- New `heat_stage_text_sensor` maps numeric stage values (0-3) to human-readable labels: Off, Low, Med, High
- Existing numeric `heat_stage_sensor` remains alongside for automations

### Internalize Allow Control Switch (**BREAKING**)
- `AllowControlSwitch` class now lives inside the component (optimistic, defaults to OFF)
- **Migration**: Remove the separate `switch:` / `platform: template` block and move `allow_control_switch:` inside the `abcdesp:` block with just a `name:` key
- Before:
  ```yaml
  switch:
    - platform: template
      name: "Allow Control"
      id: allow_control
      optimistic: true
      restore_mode: RESTORE_DEFAULT_OFF
  abcdesp:
    allow_control_switch: allow_control
  ```
- After:
  ```yaml
  abcdesp:
    allow_control_switch:
      name: "Allow Control"
  ```

### Away/Vacation Preset
- Polls 3B04 vacation register (poll cycle now 3B02 → 3B03 → 3B04)
- Climate entity exposes `CLIMATE_PRESET_HOME` / `CLIMATE_PRESET_AWAY`
- Setting Away activates vacation mode (7 days, 55-85°F defaults)
- Setting Home deactivates vacation mode
- Preset state reflects actual thermostat vacation status

### Tests
- Vacation register (3B04) parsing test
- Heat stage label mapping test with out-of-range validation