### PR TITLE
feat: entity polish — categories, HP stage text sensor, blower device_class

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ impersonating a SAM (System Access Module).
 | Heat Stage | Sensor | Current heat stage (0=off, 1=low, 2=med, 3=high) |
 | HP Coil Temperature | Sensor | Heat pump coil temperature in °F |
 | HP Stage | Sensor | Heat pump compressor stage |
+| HP Stage Label | Text Sensor | Heat pump stage as text (Off/Low/High) |
 | Communication OK | Binary Sensor | Whether the ESP32 is receiving responses from the thermostat (goes offline after 30s of no response) |
 | Hold Active | Binary Sensor | Whether zone 1 is in hold mode (schedule overridden) |
 | Clear Hold | Button | Clears hold on zone 1, resuming the thermostat's built-in schedule (requires Allow Control ON) |

--- a/abcdesp.yaml
+++ b/abcdesp.yaml
@@ -67,6 +67,8 @@ abcdesp:
     name: "HP Coil Temperature"
   hp_stage_sensor:
     name: "HP Stage"
+  hp_stage_text_sensor:
+    name: "HP Stage Label"
   blower_sensor:
     name: "Blower Running"
   comms_ok_sensor:

--- a/components/abcdesp/__init__.py
+++ b/components/abcdesp/__init__.py
@@ -3,8 +3,10 @@ import esphome.config_validation as cv
 from esphome.components import climate, sensor, text_sensor, binary_sensor, switch, button, uart
 from esphome.const import (
     DEVICE_CLASS_HUMIDITY,
+    DEVICE_CLASS_RUNNING,
     DEVICE_CLASS_TEMPERATURE,
     DEVICE_CLASS_CONNECTIVITY,
+    ENTITY_CATEGORY_CONFIG,
     ENTITY_CATEGORY_DIAGNOSTIC,
     ICON_FAN,
     STATE_CLASS_MEASUREMENT,
@@ -33,6 +35,7 @@ CONF_ALLOW_CONTROL_SWITCH = "allow_control_switch"
 CONF_INDOOR_HUMIDITY_SENSOR = "indoor_humidity_sensor"
 CONF_HP_COIL_TEMP_SENSOR = "hp_coil_temp_sensor"
 CONF_HP_STAGE_SENSOR = "hp_stage_sensor"
+CONF_HP_STAGE_TEXT_SENSOR = "hp_stage_text_sensor"
 CONF_COMMS_OK_SENSOR = "comms_ok_sensor"
 CONF_HOLD_ACTIVE_SENSOR = "hold_active_sensor"
 CONF_CLEAR_HOLD_BUTTON = "clear_hold_button"
@@ -84,7 +87,12 @@ CONFIG_SCHEMA = (
                 state_class=STATE_CLASS_MEASUREMENT,
                 entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
             ),
+            cv.Optional(CONF_HP_STAGE_TEXT_SENSOR): text_sensor.text_sensor_schema(
+                icon="mdi:heat-pump",
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+            ),
             cv.Optional(CONF_BLOWER_SENSOR): binary_sensor.binary_sensor_schema(
+                device_class=DEVICE_CLASS_RUNNING,
                 entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
             ),
             cv.Optional(CONF_COMMS_OK_SENSOR): binary_sensor.binary_sensor_schema(
@@ -97,10 +105,12 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_CLEAR_HOLD_BUTTON): button.button_schema(
                 ClearHoldButton,
                 icon="mdi:hand-back-left-off",
+                entity_category=ENTITY_CATEGORY_CONFIG,
             ),
             cv.Optional(CONF_ALLOW_CONTROL_SWITCH): switch.switch_schema(
                 AllowControlSwitch,
                 icon="mdi:lock-open-variant",
+                entity_category=ENTITY_CATEGORY_CONFIG,
             ),
         }
     )
@@ -143,6 +153,10 @@ async def to_code(config):
     if CONF_HP_STAGE_SENSOR in config:
         sens = await sensor.new_sensor(config[CONF_HP_STAGE_SENSOR])
         cg.add(var.set_hp_stage_sensor(sens))
+
+    if CONF_HP_STAGE_TEXT_SENSOR in config:
+        sens = await text_sensor.new_text_sensor(config[CONF_HP_STAGE_TEXT_SENSOR])
+        cg.add(var.set_hp_stage_text_sensor(sens))
 
     if CONF_BLOWER_SENSOR in config:
         sens = await binary_sensor.new_binary_sensor(config[CONF_BLOWER_SENSOR])

--- a/components/abcdesp/abcdesp.cpp
+++ b/components/abcdesp/abcdesp.cpp
@@ -999,8 +999,15 @@ void AbcdEspComponent::publish_sensors() {
     prev_hp_coil_temp_ = hp_coil_temp_;
   }
 
-  if (hp_stage_sensor_ != nullptr && hp_stage_ != prev_hp_stage_) {
-    hp_stage_sensor_->publish_state(static_cast<float>(hp_stage_));
+  if (hp_stage_ != prev_hp_stage_) {
+    if (hp_stage_sensor_ != nullptr) {
+      hp_stage_sensor_->publish_state(static_cast<float>(hp_stage_));
+    }
+    if (hp_stage_text_sensor_ != nullptr) {
+      static const char *const kHpStageLabels[] = {"Off", "Low", "High"};
+      uint8_t idx = (hp_stage_ <= 2) ? hp_stage_ : 0;
+      hp_stage_text_sensor_->publish_state(kHpStageLabels[idx]);
+    }
     prev_hp_stage_ = hp_stage_;
   }
 }
@@ -1024,6 +1031,7 @@ void AbcdEspComponent::dump_config() {
   LOG_SENSOR("  ", "Indoor Humidity", indoor_humidity_sensor_);
   LOG_SENSOR("  ", "HP Coil Temp", hp_coil_temp_sensor_);
   LOG_SENSOR("  ", "HP Stage", hp_stage_sensor_);
+  LOG_TEXT_SENSOR("  ", "HP Stage Label", hp_stage_text_sensor_);
   LOG_BINARY_SENSOR("  ", "Comms OK", comms_ok_sensor_);
   LOG_BINARY_SENSOR("  ", "Hold Active", hold_active_sensor_);
   if (clear_hold_button_ != nullptr) {

--- a/components/abcdesp/abcdesp.h
+++ b/components/abcdesp/abcdesp.h
@@ -127,6 +127,7 @@ class AbcdEspComponent : public Component,
   void set_indoor_humidity_sensor(sensor::Sensor *s) { indoor_humidity_sensor_ = s; }
   void set_hp_coil_temp_sensor(sensor::Sensor *s) { hp_coil_temp_sensor_ = s; }
   void set_hp_stage_sensor(sensor::Sensor *s) { hp_stage_sensor_ = s; }
+  void set_hp_stage_text_sensor(text_sensor::TextSensor *s) { hp_stage_text_sensor_ = s; }
   void set_comms_ok_sensor(binary_sensor::BinarySensor *s) { comms_ok_sensor_ = s; }
   void set_hold_active_sensor(binary_sensor::BinarySensor *s) { hold_active_sensor_ = s; }
   void set_clear_hold_button(ClearHoldButton *b) { clear_hold_button_ = b; }
@@ -247,6 +248,7 @@ class AbcdEspComponent : public Component,
   sensor::Sensor *indoor_humidity_sensor_{nullptr};
   sensor::Sensor *hp_coil_temp_sensor_{nullptr};
   sensor::Sensor *hp_stage_sensor_{nullptr};
+  text_sensor::TextSensor *hp_stage_text_sensor_{nullptr};
 
   // Control gate
   switch_::Switch *allow_control_switch_{nullptr};

--- a/tests/test_protocol.cpp
+++ b/tests/test_protocol.cpp
@@ -499,6 +499,29 @@ TEST(heat_stage_label_mapping) {
   PASS();
 }
 
+TEST(hp_stage_label_mapping) {
+  printf("test_hp_stage_label_mapping\n");
+  // Verify the HP stage label mapping logic used in publish_sensors
+  static const char *const kHpStageLabels[] = {"Off", "Low", "High"};
+
+  for (uint8_t stage = 0; stage <= 2; stage++) {
+    uint8_t idx = (stage <= 2) ? stage : 0;
+    const char *label = kHpStageLabels[idx];
+    ASSERT_TRUE(label != nullptr);
+  }
+
+  // Verify specific mappings
+  ASSERT_EQ(strcmp(kHpStageLabels[0], "Off"), 0);
+  ASSERT_EQ(strcmp(kHpStageLabels[1], "Low"), 0);
+  ASSERT_EQ(strcmp(kHpStageLabels[2], "High"), 0);
+
+  // Out-of-range should map to index 0 (Off)
+  uint8_t bad_stage = 5;
+  uint8_t idx = (bad_stage <= 2) ? bad_stage : 0;
+  ASSERT_EQ(idx, 0);
+  PASS();
+}
+
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Changes

### Entity category cleanup
- `allow_control_switch` → `ENTITY_CATEGORY_CONFIG` (keeps it off the default device page)
- `clear_hold_button` → `ENTITY_CATEGORY_CONFIG`

### Blower binary sensor
- Added `DEVICE_CLASS_RUNNING` for proper HA icon/display

### HP Stage Text Sensor (new entity)
- Adds `hp_stage_text_sensor` mirroring the existing `heat_stage_text_sensor` pattern
- Maps HP compressor stage to human-readable labels: Off / Low / High
- Added to `__init__.py`, `abcdesp.h`, `abcdesp.cpp`, example YAML, README
- Unit test added for label mapping logic

### Fixes
- Fixed deduplication logic: HP stage numeric + text sensors now share a single change check instead of the text sensor never updating (prev value was already updated by the numeric sensor block)