### PR TITLE
feat: configurable temporary hold duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,18 @@ To enable control, toggle the **Allow Control** switch in Home Assistant. The sw
 
 ## Hold Behavior
 
-When you change setpoints from Home Assistant, the component places the thermostat into **hold** mode. This means the thermostat's built-in schedule is overridden until the hold is cleared.
+When you change setpoints from Home Assistant, the component places the thermostat into **hold** mode. This means the thermostat's built-in schedule is overridden.
 
-To resume the thermostat's schedule, press the **Clear Hold** button in Home Assistant (requires the Allow Control switch to be ON). You can also clear the hold at the thermostat itself.
+By default, hold is **permanent** (matching the thermostat's native behavior when you adjust setpoints at the unit). To use a **temporary hold** that automatically clears after a set time, add the `hold_duration_minutes` option:
+
+```yaml
+abcdesp:
+  hold_duration_minutes: 120  # auto-clear hold after 2 hours (0 = permanent, default)
+```
+
+When a temporary hold expires, the component sends a clear-hold command and the thermostat resumes its built-in schedule. If the ESP32 reboots during a temporary hold, the hold will persist as permanent (the timer is not saved across reboots).
+
+To clear a hold manually at any time, press the **Clear Hold** button in Home Assistant (requires the Allow Control switch to be ON). You can also clear the hold at the thermostat itself.
 
 The **Hold Active** binary sensor shows whether zone 1 is currently in hold mode.
 

--- a/abcdesp.yaml
+++ b/abcdesp.yaml
@@ -47,6 +47,7 @@ abcdesp:
   name: "HVAC"
   icon: "mdi:hvac"
   uart_id: abcdesp_uart
+  hold_duration_minutes: 120  # 0 = permanent hold (default)
   flow_pin:
     number: GPIO4
     mode:

--- a/components/abcdesp/__init__.py
+++ b/components/abcdesp/__init__.py
@@ -36,6 +36,7 @@ CONF_HP_STAGE_SENSOR = "hp_stage_sensor"
 CONF_COMMS_OK_SENSOR = "comms_ok_sensor"
 CONF_HOLD_ACTIVE_SENSOR = "hold_active_sensor"
 CONF_CLEAR_HOLD_BUTTON = "clear_hold_button"
+CONF_HOLD_DURATION_MINUTES = "hold_duration_minutes"
 
 CONFIG_SCHEMA = (
     climate.climate_schema(AbcdEspComponent)
@@ -102,6 +103,9 @@ CONFIG_SCHEMA = (
                 AllowControlSwitch,
                 icon="mdi:lock-open-variant",
             ),
+            cv.Optional(CONF_HOLD_DURATION_MINUTES, default=0): cv.int_range(
+                min=0, max=1440
+            ),
         }
     )
     .extend(uart.UART_DEVICE_SCHEMA)
@@ -164,3 +168,5 @@ async def to_code(config):
     if CONF_ALLOW_CONTROL_SWITCH in config:
         sw = await switch.new_switch(config[CONF_ALLOW_CONTROL_SWITCH])
         cg.add(var.set_allow_control_switch(sw))
+
+    cg.add(var.set_hold_duration_minutes(config[CONF_HOLD_DURATION_MINUTES]))

--- a/components/abcdesp/abcdesp.cpp
+++ b/components/abcdesp/abcdesp.cpp
@@ -306,6 +306,15 @@ void AbcdEspComponent::loop() {
     last_poll_ms_ = now;
   }
 
+  // --- Auto-clear temporary hold ---
+  if (hold_duration_minutes_ > 0 && hold_set_ms_ > 0 &&
+      (now - hold_set_ms_ >= static_cast<uint32_t>(hold_duration_minutes_) * 60000U)) {
+    ESP_LOGI(TAG, "Temporary hold expired after %d minutes — clearing",
+             hold_duration_minutes_);
+    hold_set_ms_ = 0;
+    clear_hold();
+  }
+
   // --- Send pending write if gap is satisfied ---
   if (write_pending_ && !awaiting_response_ &&
       (now - last_send_ms_ >= MIN_FRAME_GAP_MS)) {
@@ -804,6 +813,7 @@ void AbcdEspComponent::control(const climate::ClimateCall &call) {
     if (setpoints_changed) {
       write_buf_[11] = 0x01;
       flags |= 0x0002;
+      hold_set_ms_ = millis();
     }
     write_buf_[1] = (flags >> 8) & 0xFF;
     write_buf_[2] = flags & 0xFF;
@@ -1013,6 +1023,11 @@ void AbcdEspComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "  SAM Address: 0x%04X", ADDR_SAM);
   ESP_LOGCONFIG(TAG, "  Thermostat Address: 0x%04X", ADDR_TSTAT);
   ESP_LOGCONFIG(TAG, "  Poll Interval: %d ms", POLL_INTERVAL_MS);
+  if (hold_duration_minutes_ > 0) {
+    ESP_LOGCONFIG(TAG, "  Hold Duration: %d minutes (temporary)", hold_duration_minutes_);
+  } else {
+    ESP_LOGCONFIG(TAG, "  Hold Duration: permanent");
+  }
   if (flow_pin_ != nullptr) {
     LOG_PIN("  Flow Control Pin: ", flow_pin_);
   }
@@ -1055,6 +1070,7 @@ void AbcdEspComponent::clear_hold() {
 
   write_len_ = 28;
   write_pending_ = true;
+  hold_set_ms_ = 0;  // cancel any pending auto-clear
 
   ESP_LOGI(TAG, "Queued clear hold for zone 1");
 }

--- a/components/abcdesp/abcdesp.h
+++ b/components/abcdesp/abcdesp.h
@@ -130,6 +130,7 @@ class AbcdEspComponent : public Component,
   void set_comms_ok_sensor(binary_sensor::BinarySensor *s) { comms_ok_sensor_ = s; }
   void set_hold_active_sensor(binary_sensor::BinarySensor *s) { hold_active_sensor_ = s; }
   void set_clear_hold_button(ClearHoldButton *b) { clear_hold_button_ = b; }
+  void set_hold_duration_minutes(uint16_t minutes) { hold_duration_minutes_ = minutes; }
 
   // Clear hold — sends a 3B03 write clearing the hold flag
   void clear_hold();
@@ -258,6 +259,10 @@ class AbcdEspComponent : public Component,
   binary_sensor::BinarySensor *hold_active_sensor_{nullptr};
   bool prev_hold_active_{false};
   bool hold_active_initialized_{false};
+
+  // Temporary hold
+  uint16_t hold_duration_minutes_{0};  // 0 = permanent hold (default)
+  uint32_t hold_set_ms_{0};            // millis() when hold was set by HA
 
   // Clear hold button
   ClearHoldButton *clear_hold_button_{nullptr};


### PR DESCRIPTION
## Temporary Hold Duration

Currently, every setpoint change from HA places the thermostat into **permanent hold**, overriding the schedule until manually cleared. This PR adds a configurable `hold_duration_minutes` option that auto-clears hold after a set time.

### Configuration

```yaml
abcdesp:
  hold_duration_minutes: 120  # auto-clear after 2 hours (0 = permanent, default)
```

### How it works
- When a setpoint change triggers hold, the component records the timestamp
- In `loop()`, if the configured duration has elapsed, `clear_hold()` is called automatically
- Manual "Clear Hold" button press also cancels the timer
- Default is `0` (permanent hold) — existing behavior is unchanged

### Edge cases
- If `allow_control_switch` is OFF when the timer expires, the clear-hold command is blocked (correct — don't send commands when control is disabled) and the timer is consumed (no retry loop)
- If ESP32 reboots during a temporary hold, the hold persists as permanent (documented in README)
- Range: 0–1440 minutes (up to 24 hours)