### PR TITLE
Promote failure logging to ESP_LOGE

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -45,7 +45,7 @@ _(All planned sensors have been implemented.)_
 
 ## Logging
 
-- Promote important failure conditions (repeated CRC failures, NAK'd writes) from `ESP_LOGW` to `ESP_LOGE` so they surface in HA's log viewer
+- ~~Promote important failure conditions (repeated CRC failures, NAK'd writes) from `ESP_LOGW` to `ESP_LOGE` so they surface in HA's log viewer~~ — done: CRC failures tracked with counter, ESP_LOGE after 10 consecutive; NAK and comms-lost promoted to ESP_LOGE
 
 ## Other
 

--- a/components/abcdesp/abcdesp.cpp
+++ b/components/abcdesp/abcdesp.cpp
@@ -251,6 +251,10 @@ void AbcdEspComponent::loop() {
 
     InfinityFrame frame;
     if (parse_frame(rx_buf_, frame_len, frame)) {
+      if (crc_fail_count_ > 0) {
+        ESP_LOGD(TAG, "CRC re-synced after %u failures", crc_fail_count_);
+        crc_fail_count_ = 0;
+      }
       handle_frame(frame);
       // Consume the frame
       rx_len_ -= frame_len;
@@ -259,6 +263,11 @@ void AbcdEspComponent::loop() {
       }
     } else {
       // CRC failed — skip one byte, try to re-sync
+      crc_fail_count_++;
+      if (crc_fail_count_ == CRC_FAIL_LOG_THRESHOLD) {
+        ESP_LOGE(TAG, "Repeated CRC failures (%u consecutive) — check RS-485 wiring",
+                 crc_fail_count_);
+      }
       memmove(rx_buf_, rx_buf_ + 1, --rx_len_);
     }
   }
@@ -274,7 +283,7 @@ void AbcdEspComponent::loop() {
   if (comms_ok_ && last_successful_response_ms_ > 0 &&
       (millis() - last_successful_response_ms_ > COMMS_TIMEOUT_MS)) {
     comms_ok_ = false;
-    ESP_LOGW(TAG, "Communication lost — no response in %d ms", COMMS_TIMEOUT_MS);
+    ESP_LOGE(TAG, "Communication lost — no response in %d ms", COMMS_TIMEOUT_MS);
     if (comms_ok_sensor_ != nullptr) {
       comms_ok_sensor_->publish_state(false);
     }
@@ -357,7 +366,7 @@ void AbcdEspComponent::handle_frame(const InfinityFrame &frame) {
 
   // --- NAK to our request ---
   if (frame.func == FUNC_NAK && frame.dst == ADDR_SAM) {
-    ESP_LOGW(TAG, "NAK received from 0x%04X for pending 0x%02X%02X — command rejected by thermostat",
+    ESP_LOGE(TAG, "NAK received from 0x%04X for pending 0x%02X%02X — command rejected by thermostat",
              frame.src, pending_table_, pending_row_);
     awaiting_response_ = false;
     return;

--- a/components/abcdesp/abcdesp.h
+++ b/components/abcdesp/abcdesp.h
@@ -71,6 +71,9 @@ static const uint16_t RX_BUF_SIZE             = 512;
 // Communication health — consider comms failed if no response in this many ms
 static const uint32_t COMMS_TIMEOUT_MS          = 30000;
 
+// CRC failure threshold — log ESP_LOGE after this many consecutive failures
+static const uint16_t CRC_FAIL_LOG_THRESHOLD    = 10;
+
 // CRC-16/ARC: poly 0x8005, reflected, init 0x0000
 static const uint16_t CRC_POLY          = 0xA001; // reflected 0x8005
 
@@ -194,6 +197,9 @@ class AbcdEspComponent : public Component,
   // Communication health
   uint32_t last_successful_response_ms_{0};
   bool comms_ok_{false};
+
+  // CRC failure tracking
+  uint16_t crc_fail_count_{0};
 
   // Bus device detection
   bool seen_thermostat_{false};

--- a/tests/test_protocol.cpp
+++ b/tests/test_protocol.cpp
@@ -42,6 +42,9 @@ static const uint8_t FAN_LOW  = 0x01;
 static const uint8_t FAN_MED  = 0x02;
 static const uint8_t FAN_HIGH = 0x03;
 
+// CRC failure threshold (mirrors abcdesp.h)
+static const uint16_t CRC_FAIL_LOG_THRESHOLD = 10;
+
 struct InfinityFrame {
   uint16_t dst;
   uint16_t src;
@@ -519,6 +522,46 @@ TEST(hp_stage_label_mapping) {
   uint8_t bad_stage = 5;
   uint8_t idx = (bad_stage <= 2) ? bad_stage : 0;
   ASSERT_EQ(idx, 0);
+  PASS();
+}
+
+TEST(crc_fail_counter_logic) {
+  printf("test_crc_fail_counter_logic\n");
+  // Simulates the CRC failure counting logic from loop():
+  //   - counter increments on each CRC failure
+  //   - resets to 0 when a valid frame is parsed
+  //   - threshold triggers error log at CRC_FAIL_LOG_THRESHOLD
+  uint16_t crc_fail_count = 0;
+  bool error_logged = false;
+
+  // Simulate consecutive CRC failures up to threshold
+  for (uint16_t i = 0; i < CRC_FAIL_LOG_THRESHOLD; i++) {
+    crc_fail_count++;
+    if (crc_fail_count == CRC_FAIL_LOG_THRESHOLD) {
+      error_logged = true;
+    }
+  }
+  ASSERT_EQ(crc_fail_count, CRC_FAIL_LOG_THRESHOLD);
+  ASSERT_TRUE(error_logged);
+
+  // Simulate successful parse — counter resets
+  crc_fail_count = 0;
+  ASSERT_EQ(crc_fail_count, 0);
+
+  // Simulate a few failures then success — should NOT trigger error
+  error_logged = false;
+  for (uint16_t i = 0; i < CRC_FAIL_LOG_THRESHOLD - 1; i++) {
+    crc_fail_count++;
+    if (crc_fail_count == CRC_FAIL_LOG_THRESHOLD) {
+      error_logged = true;
+    }
+  }
+  ASSERT_EQ(crc_fail_count, CRC_FAIL_LOG_THRESHOLD - 1);
+  ASSERT_TRUE(!error_logged);
+
+  // Success resets counter
+  crc_fail_count = 0;
+  ASSERT_EQ(crc_fail_count, 0);
   PASS();
 }
 


### PR DESCRIPTION
Promote important failure conditions from `ESP_LOGW` to `ESP_LOGE` so they surface in HA's log viewer.

## Changes

- **CRC failures**: Track consecutive failures with a counter (`crc_fail_count_`). After 10 consecutive CRC failures, log `ESP_LOGE` suggesting RS-485 wiring issues. Counter resets when a valid frame is parsed.
- **NAK'd writes**: Promoted from `ESP_LOGW` to `ESP_LOGE` — a NAK means the thermostat rejected our command, which is always significant.
- **Communication lost**: Promoted from `ESP_LOGW` to `ESP_LOGE` — total communication loss is a critical failure.

## Files changed

- `components/abcdesp/abcdesp.h` — added `CRC_FAIL_LOG_THRESHOLD` constant and `crc_fail_count_` member
- `components/abcdesp/abcdesp.cpp` — CRC counter logic in loop, promoted log levels
- `tests/test_protocol.cpp` — added `crc_fail_counter_logic` test
- `TODO.md` — marked logging item done