### PR TITLE
Add HVAC dashboard for Home Assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,3 +143,20 @@ esphome:
 ```
 
 Each device will appear as a separate ESPHome integration in Home Assistant with its own set of entities. The `name` field determines the device's mDNS hostname and HA entity ID prefix.
+
+## Dashboard
+
+A ready-to-use Home Assistant dashboard is included in `dashboard/hvac-dashboard.yaml`. It uses only built-in HA cards (no HACS or custom cards required) and shows:
+
+- **Thermostat card** — ring dial with current temperature, setpoints, mode, fan, and preset controls
+- **Conditions** — outdoor temperature, indoor humidity, and HP coil temperature at a glance
+- **System status** — blower, heat stage, HP stage, airflow CFM
+- **Controls** — hold status, clear hold, allow control, communication health
+
+To use it:
+
+1. In Home Assistant, go to **Settings → Dashboards → Add Dashboard**
+2. Create a new dashboard, open it, and switch to YAML mode (three-dot menu → Raw configuration editor)
+3. Paste the contents of `dashboard/hvac-dashboard.yaml`
+
+Entity IDs assume `esphome.name: abcdesp`. If you changed your device name, find/replace `abcdesp_` with your device name + underscore.

--- a/TODO.md
+++ b/TODO.md
@@ -40,8 +40,8 @@ _(All planned sensors have been implemented.)_
 
 ## Home Assistant Dashboard
 
-- Ship a custom thermostat card or dashboard that reproduces the data displayed on the physical thermostat (current temp, humidity, setpoints, mode, outdoor temp, system status)
-- Document which HA thermostat card works best and any quirks
+- ~~Ship a custom thermostat card or dashboard that reproduces the data displayed on the physical thermostat (current temp, humidity, setpoints, mode, outdoor temp, system status)~~ — done: `dashboard/hvac-dashboard.yaml` using built-in HA thermostat + glance + entities cards
+- ~~Document which HA thermostat card works best and any quirks~~ — done: uses built-in `type: thermostat` card with `show_current_as_primary: true`; documented in README
 
 ## Logging
 

--- a/dashboard/hvac-dashboard.yaml
+++ b/dashboard/hvac-dashboard.yaml
@@ -1,0 +1,106 @@
+# ==========================================================================
+# Carrier Infinity HVAC Dashboard
+#
+# Reproduces the key information shown on the physical thermostat:
+#   - Current temperature (large, center)
+#   - Outdoor temperature + indoor humidity (top bar on thermostat)
+#   - Mode, fan mode, setpoints
+#   - System status (heat stage, HP stage, airflow, blower)
+#   - Hold status and controls
+#
+# Usage:
+#   1. In Home Assistant, go to Settings > Dashboards > Add Dashboard
+#   2. Create a new dashboard, switch to YAML mode
+#   3. Paste this content (or import individual cards into an existing dashboard)
+#
+# Entity IDs assume esphome.name = "abcdesp". If yours differs, find/replace
+# "abcdesp_" with your ESPHome device name + underscore.
+# ==========================================================================
+
+views:
+  - title: HVAC
+    icon: mdi:hvac
+    cards:
+      # ----------------------------------------------------------------
+      # Primary thermostat card — ring dial with current temp, setpoints,
+      # mode, fan, and preset controls
+      # ----------------------------------------------------------------
+      - type: thermostat
+        entity: climate.abcdesp_hvac
+        show_current_as_primary: true
+        name: Carrier Infinity
+        features:
+          - type: climate-hvac-modes
+            hvac_modes:
+              - "off"
+              - heat
+              - cool
+              - heat_cool
+          - type: climate-fan-modes
+            fan_modes:
+              - auto
+              - low
+              - medium
+              - high
+          - type: climate-preset-modes
+            preset_modes:
+              - home
+              - away
+
+      # ----------------------------------------------------------------
+      # Outdoor & indoor conditions — the physical thermostat shows
+      # outdoor temp in the top bar and humidity on an alternate screen.
+      # This card shows both at a glance.
+      # ----------------------------------------------------------------
+      - type: glance
+        title: Conditions
+        show_state: true
+        entities:
+          - entity: sensor.abcdesp_outdoor_temperature
+            name: Outside
+            icon: mdi:thermometer
+          - entity: sensor.abcdesp_indoor_humidity
+            name: Humidity
+            icon: mdi:water-percent
+          - entity: sensor.abcdesp_hp_coil_temperature
+            name: HP Coil
+            icon: mdi:coolant-temperature
+
+      # ----------------------------------------------------------------
+      # System status — heat stage, HP stage, airflow, blower
+      # (data from air handler and heat pump)
+      # ----------------------------------------------------------------
+      - type: entities
+        title: System Status
+        entities:
+          - entity: binary_sensor.abcdesp_blower_running
+            name: Blower
+            icon: mdi:fan
+          - entity: text_sensor.abcdesp_heat_stage_label
+            name: Heat Stage
+            icon: mdi:fire
+          - entity: text_sensor.abcdesp_hp_stage_label
+            name: HP Stage
+            icon: mdi:heat-pump-outline
+          - entity: sensor.abcdesp_airflow_cfm
+            name: Airflow
+            icon: mdi:weather-windy
+
+      # ----------------------------------------------------------------
+      # Hold & controls
+      # ----------------------------------------------------------------
+      - type: entities
+        title: Controls
+        entities:
+          - entity: binary_sensor.abcdesp_hold_active
+            name: Hold Active
+            icon: mdi:hand-back-right
+          - entity: button.abcdesp_clear_hold
+            name: Clear Hold
+            icon: mdi:hand-back-right-off
+          - entity: switch.abcdesp_allow_control
+            name: Allow Control
+            icon: mdi:shield-lock-outline
+          - entity: binary_sensor.abcdesp_communication_ok
+            name: Communication
+            icon: mdi:lan-connect


### PR DESCRIPTION
Adds a ready-to-use Home Assistant dashboard that reproduces the key data shown on the physical Carrier Infinity thermostat.

## Dashboard layout

| Card | Physical thermostat equivalent |
|---|---|
| **Thermostat** (ring dial) | Big current temp + setpoints + mode/fan. Shows dual setpoints (heat + cool) in auto mode, single setpoint in heat/cool mode. |
| **Conditions** (glance) | "OUTSIDE: 45°" top bar + humidity (alternate screen) + HP coil temp |
| **System Status** (entities) | Blower, heat stage, HP stage, airflow CFM |
| **Controls** (entities) | Hold status, clear hold, allow control, comms health |

## Details

- Uses only built-in HA cards — no HACS or custom cards required
- `show_current_as_primary: true` makes current temp the big number (matching the thermostat's display)
- Climate features (mode selector, fan mode, presets) added as card features
- Dashboard documented in README with setup instructions

## Files changed

- `dashboard/hvac-dashboard.yaml` — new dashboard config
- `README.md` — added Dashboard section with usage instructions
- `TODO.md` — marked dashboard items done