### PR TITLE
feat: configurable vacation parameters

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -10,4 +10,4 @@ Currently only Zone 1 is read and controlled. The Carrier Infinity protocol supp
 - Allow per-zone control of setpoints and fan mode
 
 ## Remaining work
-- **Configurable vacation parameters** — vacation preset currently uses hardcoded values (7 days, 60–80°F, fan auto). Consider exposing as YAML config or number entities. Low priority — matches thermostat's native behavior.
+- ~~**Configurable vacation parameters**~~ — done: `vacation_days_number`, `vacation_min_temp_number`, and `vacation_max_temp_number` entities configure vacation settings before activating Away preset; `parse_vacation` updates entities from thermostat state when vacation is active; defaults to 7 days, 60–80°F if entities not configured

--- a/abcdesp.yaml
+++ b/abcdesp.yaml
@@ -92,6 +92,12 @@ abcdesp:
     name: "Hold Duration"
   set_hold_time_number:
     name: "Set Hold Time"
+  vacation_days_number:
+    name: "Vacation Days"
+  vacation_min_temp_number:
+    name: "Vacation Min Temp"
+  vacation_max_temp_number:
+    name: "Vacation Max Temp"
 
 # ----------------------------------------------------------------
 # Diagnostics

--- a/components/abcdesp/__init__.py
+++ b/components/abcdesp/__init__.py
@@ -26,6 +26,9 @@ ClearHoldButton = abcdesp_ns.class_("ClearHoldButton", button.Button)
 AllowControlSwitch = abcdesp_ns.class_("AllowControlSwitch", switch.Switch)
 HoldDurationNumber = abcdesp_ns.class_("HoldDurationNumber", number.Number)
 SetHoldTimeNumber = abcdesp_ns.class_("SetHoldTimeNumber", number.Number)
+VacationDaysNumber = abcdesp_ns.class_("VacationDaysNumber", number.Number)
+VacationMinTempNumber = abcdesp_ns.class_("VacationMinTempNumber", number.Number)
+VacationMaxTempNumber = abcdesp_ns.class_("VacationMaxTempNumber", number.Number)
 
 CONF_FLOW_PIN = "flow_pin"
 CONF_OUTDOOR_TEMP_SENSOR = "outdoor_temp_sensor"
@@ -45,6 +48,9 @@ CONF_CLEAR_HOLD_BUTTON = "clear_hold_button"
 CONF_HOLD_DURATION_MINUTES = "hold_duration_minutes"
 CONF_HOLD_DURATION_NUMBER = "hold_duration_number"
 CONF_SET_HOLD_TIME_NUMBER = "set_hold_time_number"
+CONF_VACATION_DAYS_NUMBER = "vacation_days_number"
+CONF_VACATION_MIN_TEMP_NUMBER = "vacation_min_temp_number"
+CONF_VACATION_MAX_TEMP_NUMBER = "vacation_max_temp_number"
 
 CONFIG_SCHEMA = (
     climate.climate_schema(AbcdEspComponent)
@@ -137,6 +143,23 @@ CONFIG_SCHEMA = (
                 icon="mdi:timer-edit",
                 entity_category=ENTITY_CATEGORY_CONFIG,
             ),
+            cv.Optional(CONF_VACATION_DAYS_NUMBER): number.number_schema(
+                VacationDaysNumber,
+                icon="mdi:calendar-range",
+                entity_category=ENTITY_CATEGORY_CONFIG,
+            ),
+            cv.Optional(CONF_VACATION_MIN_TEMP_NUMBER): number.number_schema(
+                VacationMinTempNumber,
+                unit_of_measurement="°F",
+                icon="mdi:thermometer-low",
+                entity_category=ENTITY_CATEGORY_CONFIG,
+            ),
+            cv.Optional(CONF_VACATION_MAX_TEMP_NUMBER): number.number_schema(
+                VacationMaxTempNumber,
+                unit_of_measurement="°F",
+                icon="mdi:thermometer-high",
+                entity_category=ENTITY_CATEGORY_CONFIG,
+            ),
         }
     )
     .extend(uart.UART_DEVICE_SCHEMA)
@@ -227,5 +250,35 @@ async def to_code(config):
         )
         cg.add(num.set_parent(var))
         cg.add(var.set_set_hold_time_number(num))
+
+    if CONF_VACATION_DAYS_NUMBER in config:
+        num = await number.new_number(
+            config[CONF_VACATION_DAYS_NUMBER],
+            min_value=1,
+            max_value=30,
+            step=1,
+        )
+        cg.add(num.set_parent(var))
+        cg.add(var.set_vacation_days_number(num))
+
+    if CONF_VACATION_MIN_TEMP_NUMBER in config:
+        num = await number.new_number(
+            config[CONF_VACATION_MIN_TEMP_NUMBER],
+            min_value=40,
+            max_value=99,
+            step=1,
+        )
+        cg.add(num.set_parent(var))
+        cg.add(var.set_vacation_min_temp_number(num))
+
+    if CONF_VACATION_MAX_TEMP_NUMBER in config:
+        num = await number.new_number(
+            config[CONF_VACATION_MAX_TEMP_NUMBER],
+            min_value=40,
+            max_value=99,
+            step=1,
+        )
+        cg.add(num.set_parent(var))
+        cg.add(var.set_vacation_max_temp_number(num))
 
     cg.add(var.set_hold_duration_minutes(config[CONF_HOLD_DURATION_MINUTES]))

--- a/components/abcdesp/abcdesp.cpp
+++ b/components/abcdesp/abcdesp.cpp
@@ -50,6 +50,21 @@ void SetHoldTimeNumber::control(float value) {
 }
 
 // ==========================================================================
+// Vacation parameter numbers — store value for next vacation activation
+// ==========================================================================
+void VacationDaysNumber::control(float value) {
+  publish_state(value);
+}
+
+void VacationMinTempNumber::control(float value) {
+  publish_state(value);
+}
+
+void VacationMaxTempNumber::control(float value) {
+  publish_state(value);
+}
+
+// ==========================================================================
 // Temperature unit conversion helpers
 // ==========================================================================
 static float f_to_c(float f) { return (f - 32.0f) * 5.0f / 9.0f; }
@@ -269,6 +284,16 @@ void AbcdEspComponent::setup() {
     if (std::isnan(hold_duration_number_->state)) {
       hold_duration_number_->publish_state(static_cast<float>(hold_duration_minutes_));
     }
+  }
+  // Initialize vacation number entities with defaults
+  if (vacation_days_number_ != nullptr && std::isnan(vacation_days_number_->state)) {
+    vacation_days_number_->publish_state(7.0f);
+  }
+  if (vacation_min_temp_number_ != nullptr && std::isnan(vacation_min_temp_number_->state)) {
+    vacation_min_temp_number_->publish_state(60.0f);
+  }
+  if (vacation_max_temp_number_ != nullptr && std::isnan(vacation_max_temp_number_->state)) {
+    vacation_max_temp_number_->publish_state(80.0f);
   }
   rx_len_ = 0;
   last_poll_ms_ = millis();
@@ -751,7 +776,31 @@ void AbcdEspComponent::parse_vacation(const uint8_t *data, uint8_t len) {
   bool was_active = vacation_active_;
   vacation_active_ = (data[0] != 0);
 
-  ESP_LOGD(TAG, "3B04: vacation=%s", vacation_active_ ? "active" : "off");
+  // Parse vacation parameters if present (bytes 1-7)
+  if (len >= 8) {
+    uint16_t days_x7 = (data[1] << 8) | data[2];
+    uint8_t vac_days = (days_x7 > 0) ? (days_x7 / 7) : 0;
+    uint8_t vac_min_temp = data[3];
+    uint8_t vac_max_temp = data[4];
+
+    ESP_LOGD(TAG, "3B04: vacation=%s  days=%d  min=%d°F  max=%d°F",
+             vacation_active_ ? "active" : "off", vac_days, vac_min_temp, vac_max_temp);
+
+    // Update number entities with current thermostat values when vacation is active
+    if (vacation_active_) {
+      if (vacation_days_number_ != nullptr) {
+        vacation_days_number_->publish_state(static_cast<float>(vac_days));
+      }
+      if (vacation_min_temp_number_ != nullptr) {
+        vacation_min_temp_number_->publish_state(static_cast<float>(vac_min_temp));
+      }
+      if (vacation_max_temp_number_ != nullptr) {
+        vacation_max_temp_number_->publish_state(static_cast<float>(vac_max_temp));
+      }
+    }
+  } else {
+    ESP_LOGD(TAG, "3B04: vacation=%s", vacation_active_ ? "active" : "off");
+  }
 
   if (!vacation_initialized_ || vacation_active_ != was_active) {
     vacation_initialized_ = true;
@@ -973,20 +1022,35 @@ void AbcdEspComponent::control(const climate::ClimateCall &call) {
   if (call.get_preset().has_value()) {
     auto preset = *call.get_preset();
     if (preset == climate::CLIMATE_PRESET_AWAY && !vacation_active_) {
-      // Activate vacation with default settings:
-      // 7 days, min 60°F, max 80°F, 15% min humidity, 60% max humidity, fan auto
+      // Read vacation parameters from number entities, falling back to defaults
+      uint8_t vac_days = 7;
+      uint8_t vac_min_temp = 60;
+      uint8_t vac_max_temp = 80;
+
+      if (vacation_days_number_ != nullptr && !std::isnan(vacation_days_number_->state)) {
+        vac_days = static_cast<uint8_t>(vacation_days_number_->state);
+      }
+      if (vacation_min_temp_number_ != nullptr && !std::isnan(vacation_min_temp_number_->state)) {
+        vac_min_temp = static_cast<uint8_t>(vacation_min_temp_number_->state);
+      }
+      if (vacation_max_temp_number_ != nullptr && !std::isnan(vacation_max_temp_number_->state)) {
+        vac_max_temp = static_cast<uint8_t>(vacation_max_temp_number_->state);
+      }
+
+      uint16_t days_x7 = static_cast<uint16_t>(vac_days) * 7;
       uint8_t vac_buf[8];
-      vac_buf[0] = 0x01;  // vacation_active = 1
-      vac_buf[1] = 0x00;  // days*7 high byte (7*7=49)
-      vac_buf[2] = 0x31;  // days*7 low byte (49)
-      vac_buf[3] = 60;    // min temp °F
-      vac_buf[4] = 80;    // max temp °F
-      vac_buf[5] = 15;    // min humidity
-      vac_buf[6] = 60;    // max humidity
+      vac_buf[0] = 0x01;                       // vacation_active = 1
+      vac_buf[1] = (days_x7 >> 8) & 0xFF;      // days*7 high byte
+      vac_buf[2] = days_x7 & 0xFF;             // days*7 low byte
+      vac_buf[3] = vac_min_temp;               // min temp °F
+      vac_buf[4] = vac_max_temp;               // max temp °F
+      vac_buf[5] = 15;                         // min humidity
+      vac_buf[6] = 60;                         // max humidity
       vac_buf[7] = FAN_AUTO;
       send_write_request(ADDR_TSTAT, TBL_SAM_INFO, ROW_SAM_VACATION,
                          vac_buf, 8);
-      ESP_LOGI(TAG, "Activating vacation mode (7 days, 60-80F)");
+      ESP_LOGI(TAG, "Activating vacation mode (%d days, %d-%dF)",
+               vac_days, vac_min_temp, vac_max_temp);
     } else if (preset == climate::CLIMATE_PRESET_HOME && vacation_active_) {
       // Deactivate vacation
       uint8_t vac_buf[8];
@@ -1192,6 +1256,15 @@ void AbcdEspComponent::dump_config() {
   }
   if (set_hold_time_number_ != nullptr) {
     ESP_LOGCONFIG(TAG, "  Set Hold Time Number: configured");
+  }
+  if (vacation_days_number_ != nullptr) {
+    ESP_LOGCONFIG(TAG, "  Vacation Days Number: configured");
+  }
+  if (vacation_min_temp_number_ != nullptr) {
+    ESP_LOGCONFIG(TAG, "  Vacation Min Temp Number: configured");
+  }
+  if (vacation_max_temp_number_ != nullptr) {
+    ESP_LOGCONFIG(TAG, "  Vacation Max Temp Number: configured");
   }
 }
 

--- a/components/abcdesp/abcdesp.h
+++ b/components/abcdesp/abcdesp.h
@@ -142,6 +142,36 @@ class SetHoldTimeNumber : public number::Number {
 };
 
 // ---------------------------------------------------------------------------
+// Vacation parameter numbers — configure before activating Away preset
+// ---------------------------------------------------------------------------
+class VacationDaysNumber : public number::Number {
+ public:
+  void set_parent(AbcdEspComponent *parent) { parent_ = parent; }
+
+ protected:
+  void control(float value) override;
+  AbcdEspComponent *parent_{nullptr};
+};
+
+class VacationMinTempNumber : public number::Number {
+ public:
+  void set_parent(AbcdEspComponent *parent) { parent_ = parent; }
+
+ protected:
+  void control(float value) override;
+  AbcdEspComponent *parent_{nullptr};
+};
+
+class VacationMaxTempNumber : public number::Number {
+ public:
+  void set_parent(AbcdEspComponent *parent) { parent_ = parent; }
+
+ protected:
+  void control(float value) override;
+  AbcdEspComponent *parent_{nullptr};
+};
+
+// ---------------------------------------------------------------------------
 // Main Component
 // ---------------------------------------------------------------------------
 class AbcdEspComponent : public Component,
@@ -166,6 +196,9 @@ class AbcdEspComponent : public Component,
   void set_hold_duration_minutes(uint16_t minutes) { hold_duration_minutes_ = minutes; }
   void set_hold_duration_number(HoldDurationNumber *n) { hold_duration_number_ = n; }
   void set_set_hold_time_number(SetHoldTimeNumber *n) { set_hold_time_number_ = n; }
+  void set_vacation_days_number(VacationDaysNumber *n) { vacation_days_number_ = n; }
+  void set_vacation_min_temp_number(VacationMinTempNumber *n) { vacation_min_temp_number_ = n; }
+  void set_vacation_max_temp_number(VacationMaxTempNumber *n) { vacation_max_temp_number_ = n; }
 
   // Clear hold — sends a 3B03 write clearing the hold flag
   void clear_hold();
@@ -319,6 +352,11 @@ class AbcdEspComponent : public Component,
   // Runtime hold duration number entities
   HoldDurationNumber *hold_duration_number_{nullptr};
   SetHoldTimeNumber *set_hold_time_number_{nullptr};
+
+  // Vacation parameter number entities
+  VacationDaysNumber *vacation_days_number_{nullptr};
+  VacationMinTempNumber *vacation_min_temp_number_{nullptr};
+  VacationMaxTempNumber *vacation_max_temp_number_{nullptr};
 
   // Publish helpers
   void publish_climate_state();

--- a/tests/test_protocol.cpp
+++ b/tests/test_protocol.cpp
@@ -1283,6 +1283,227 @@ TEST(hold_duration_number_overrides_config) {
 }
 
 // ---------------------------------------------------------------------------
+// Vacation parameter payload construction tests
+// ---------------------------------------------------------------------------
+
+// Helper: build a vacation activation payload using configurable parameters.
+// Mirrors the control() logic.
+static void build_vacation_payload(uint8_t days, uint8_t min_temp,
+                                   uint8_t max_temp, uint8_t *vac_buf) {
+  uint16_t days_x7 = static_cast<uint16_t>(days) * 7;
+  vac_buf[0] = 0x01;                       // vacation_active = 1
+  vac_buf[1] = (days_x7 >> 8) & 0xFF;      // days*7 high byte
+  vac_buf[2] = days_x7 & 0xFF;             // days*7 low byte
+  vac_buf[3] = min_temp;                   // min temp °F
+  vac_buf[4] = max_temp;                   // max temp °F
+  vac_buf[5] = 15;                         // min humidity
+  vac_buf[6] = 60;                         // max humidity
+  vac_buf[7] = FAN_AUTO;
+}
+
+TEST(build_vacation_payload_defaults) {
+  printf("test_build_vacation_payload_defaults\n");
+  // Default vacation: 7 days, 60-80°F
+  uint8_t buf[8];
+  build_vacation_payload(7, 60, 80, buf);
+
+  ASSERT_EQ(buf[0], 0x01);  // active
+  // 7 * 7 = 49 = 0x0031
+  ASSERT_EQ(buf[1], 0x00);
+  ASSERT_EQ(buf[2], 0x31);
+  ASSERT_EQ(buf[3], 60);
+  ASSERT_EQ(buf[4], 80);
+  ASSERT_EQ(buf[5], 15);
+  ASSERT_EQ(buf[6], 60);
+  ASSERT_EQ(buf[7], FAN_AUTO);
+  PASS();
+}
+
+TEST(build_vacation_payload_custom) {
+  printf("test_build_vacation_payload_custom\n");
+  // Custom: 14 days, 55-85°F
+  uint8_t buf[8];
+  build_vacation_payload(14, 55, 85, buf);
+
+  ASSERT_EQ(buf[0], 0x01);
+  // 14 * 7 = 98 = 0x0062
+  uint16_t days_x7 = (buf[1] << 8) | buf[2];
+  ASSERT_EQ(days_x7, 98);
+  ASSERT_EQ(buf[3], 55);
+  ASSERT_EQ(buf[4], 85);
+  PASS();
+}
+
+TEST(build_vacation_payload_boundary_days) {
+  printf("test_build_vacation_payload_boundary_days\n");
+  uint8_t buf[8];
+
+  // 1 day (minimum)
+  build_vacation_payload(1, 60, 80, buf);
+  uint16_t days_x7 = (buf[1] << 8) | buf[2];
+  ASSERT_EQ(days_x7, 7);  // 1 * 7
+
+  // 30 days (maximum)
+  build_vacation_payload(30, 60, 80, buf);
+  days_x7 = (buf[1] << 8) | buf[2];
+  ASSERT_EQ(days_x7, 210);  // 30 * 7 = 0x00D2
+  ASSERT_EQ(buf[1], 0x00);
+  ASSERT_EQ(buf[2], 0xD2);
+  PASS();
+}
+
+TEST(build_vacation_payload_boundary_temps) {
+  printf("test_build_vacation_payload_boundary_temps\n");
+  uint8_t buf[8];
+
+  // Min temp = 40, max temp = 99
+  build_vacation_payload(7, 40, 99, buf);
+  ASSERT_EQ(buf[3], 40);
+  ASSERT_EQ(buf[4], 99);
+
+  // Narrow range: 70-72
+  build_vacation_payload(7, 70, 72, buf);
+  ASSERT_EQ(buf[3], 70);
+  ASSERT_EQ(buf[4], 72);
+  PASS();
+}
+
+TEST(build_vacation_payload_frame_roundtrip) {
+  printf("test_build_vacation_payload_frame_roundtrip\n");
+  // Build a vacation payload, wrap in WRITE frame, verify roundtrip
+  uint8_t vac_buf[8];
+  build_vacation_payload(10, 58, 78, vac_buf);
+
+  InfinityFrame f;
+  f.dst = ADDR_TSTAT;
+  f.src = ADDR_SAM;
+  f.func = FUNC_WRITE;
+  f.length = 3 + 8;
+  f.data[0] = 0x00;
+  f.data[1] = 0x3B;
+  f.data[2] = 0x04;
+  memcpy(f.data + 3, vac_buf, 8);
+
+  uint8_t frame_buf[32];
+  uint16_t frame_len;
+  build_frame(f, frame_buf, frame_len);
+
+  InfinityFrame parsed;
+  ASSERT_TRUE(parse_frame(frame_buf, frame_len, parsed));
+  ASSERT_EQ(parsed.func, FUNC_WRITE);
+  ASSERT_EQ(parsed.data[3], 0x01);   // active
+  ASSERT_EQ(parsed.data[3 + 3], 58); // min temp
+  ASSERT_EQ(parsed.data[3 + 4], 78); // max temp
+  // 10 * 7 = 70
+  uint16_t days_x7 = (parsed.data[3 + 1] << 8) | parsed.data[3 + 2];
+  ASSERT_EQ(days_x7, 70);
+  PASS();
+}
+
+TEST(vacation_number_fallback_logic) {
+  printf("test_vacation_number_fallback_logic\n");
+  // Simulate the fallback logic in control():
+  //   if number entity is configured and has a value, use it; else use default
+
+  uint8_t vac_days = 7;      // default
+  uint8_t vac_min_temp = 60;  // default
+  uint8_t vac_max_temp = 80;  // default
+
+  // When number entities are not configured (nullptr)
+  float *days_state = nullptr;
+  float *min_state = nullptr;
+  float *max_state = nullptr;
+
+  uint8_t result_days = (days_state != nullptr) ? static_cast<uint8_t>(*days_state) : vac_days;
+  uint8_t result_min = (min_state != nullptr) ? static_cast<uint8_t>(*min_state) : vac_min_temp;
+  uint8_t result_max = (max_state != nullptr) ? static_cast<uint8_t>(*max_state) : vac_max_temp;
+  ASSERT_EQ(result_days, 7);
+  ASSERT_EQ(result_min, 60);
+  ASSERT_EQ(result_max, 80);
+
+  // When number entities are configured with custom values
+  float d = 14.0f, mn = 55.0f, mx = 85.0f;
+  days_state = &d;
+  min_state = &mn;
+  max_state = &mx;
+
+  result_days = (days_state != nullptr) ? static_cast<uint8_t>(*days_state) : vac_days;
+  result_min = (min_state != nullptr) ? static_cast<uint8_t>(*min_state) : vac_min_temp;
+  result_max = (max_state != nullptr) ? static_cast<uint8_t>(*max_state) : vac_max_temp;
+  ASSERT_EQ(result_days, 14);
+  ASSERT_EQ(result_min, 55);
+  ASSERT_EQ(result_max, 85);
+  PASS();
+}
+
+TEST(parse_vacation_3b04_fields) {
+  printf("test_parse_vacation_3b04_fields\n");
+  // Verify parsing of 3B04 register content
+  uint8_t data[8] = {0};
+
+  // Active vacation: 10 days, 58-78°F
+  data[0] = 0x01;  // active
+  uint16_t days_x7 = 10 * 7;  // 70
+  data[1] = (days_x7 >> 8) & 0xFF;
+  data[2] = days_x7 & 0xFF;
+  data[3] = 58;  // min temp
+  data[4] = 78;  // max temp
+  data[5] = 15;  // min humidity
+  data[6] = 60;  // max humidity
+  data[7] = FAN_AUTO;
+
+  // Parse fields like parse_vacation does
+  bool active = (data[0] != 0);
+  ASSERT_TRUE(active);
+
+  uint16_t parsed_days_x7 = (data[1] << 8) | data[2];
+  uint8_t parsed_days = (parsed_days_x7 > 0) ? (parsed_days_x7 / 7) : 0;
+  ASSERT_EQ(parsed_days, 10);
+  ASSERT_EQ(data[3], 58);
+  ASSERT_EQ(data[4], 78);
+
+  // Inactive vacation
+  data[0] = 0x00;
+  active = (data[0] != 0);
+  ASSERT_TRUE(!active);
+  PASS();
+}
+
+TEST(vacation_deactivation_payload) {
+  printf("test_vacation_deactivation_payload\n");
+  // Verify the deactivation payload structure
+  uint8_t vac_buf[8];
+  memset(vac_buf, 0, sizeof(vac_buf));
+  vac_buf[0] = 0x00;  // vacation_active = 0
+
+  ASSERT_EQ(vac_buf[0], 0x00);
+  // All other bytes should be zero
+  for (int i = 1; i < 8; i++) {
+    ASSERT_EQ(vac_buf[i], 0);
+  }
+
+  // Wrap in frame and verify
+  InfinityFrame f;
+  f.dst = ADDR_TSTAT;
+  f.src = ADDR_SAM;
+  f.func = FUNC_WRITE;
+  f.length = 3 + 8;
+  f.data[0] = 0x00;
+  f.data[1] = 0x3B;
+  f.data[2] = 0x04;
+  memcpy(f.data + 3, vac_buf, 8);
+
+  uint8_t buf[32];
+  uint16_t buf_len;
+  build_frame(f, buf, buf_len);
+
+  InfinityFrame parsed;
+  ASSERT_TRUE(parse_frame(buf, buf_len, parsed));
+  ASSERT_EQ(parsed.data[3], 0x00);  // inactive
+  PASS();
+}
+
+// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 int main() {

--- a/tests/test_vacation_hardware.md
+++ b/tests/test_vacation_hardware.md
@@ -1,0 +1,135 @@
+# Hardware Testing Plan — Configurable Vacation Parameters
+
+These tests **must be run on real Carrier Infinity equipment** after merging.
+Monitor the thermostat display and ESPHome logs closely.
+
+## Prerequisites
+
+- ESP32 connected to Carrier Infinity bus and communicating (Comms OK = true)
+- Allow Control switch: ON
+- System NOT in vacation mode at start
+- ESPHome logs visible at DEBUG level
+- Home Assistant dashboard open showing the climate entity
+
+---
+
+## Test Cases
+
+### 1. Activate vacation with default parameters
+
+**Steps:**
+1. Do NOT set any vacation number entities (leave at defaults)
+2. Set climate preset to "Away" in HA
+
+**Expected:**
+- Thermostat enters vacation mode
+- Thermostat display shows: 7 days, 60–80°F
+- Climate entity shows preset "Away"
+- Log: "Activating vacation mode (7 days, 60-80F)"
+
+### 2. Cancel vacation from HA
+
+**Steps:**
+1. With vacation active from test 1, set preset to "Home"
+
+**Expected:**
+- Thermostat exits vacation mode
+- Climate entity shows preset "Home"
+- Log: "Deactivating vacation mode"
+
+### 3. Configure custom parameters then activate
+
+**Steps:**
+1. Set "Vacation Days" number to 14
+2. Set "Vacation Min Temp" number to 55
+3. Set "Vacation Max Temp" number to 85
+4. Set climate preset to "Away"
+
+**Expected:**
+- Thermostat enters vacation mode
+- Thermostat display shows: 14 days, 55–85°F
+- Log: "Activating vacation mode (14 days, 55-85F)"
+
+### 4. Verify number entities update from thermostat
+
+**Steps:**
+1. Activate vacation from the physical thermostat (not HA) with custom values
+2. Wait for a 3B04 poll cycle (~15 seconds)
+
+**Expected:**
+- Vacation Days, Vacation Min Temp, Vacation Max Temp number entities update to match thermostat values
+- Climate entity shows preset "Away"
+
+### 5. Activate vacation with 1 day (minimum)
+
+**Steps:**
+1. Set "Vacation Days" to 1
+2. Leave temps at defaults (60–80°F)
+3. Set preset to "Away"
+
+**Expected:**
+- Thermostat shows 1 day vacation
+- Log: "Activating vacation mode (1 days, 60-80F)"
+
+### 6. Activate vacation with 30 days (maximum)
+
+**Steps:**
+1. Set "Vacation Days" to 30
+2. Set preset to "Away"
+
+**Expected:**
+- Thermostat shows 30 day vacation
+- No NAK responses
+
+### 7. Narrow temperature range
+
+**Steps:**
+1. Set "Vacation Min Temp" to 70
+2. Set "Vacation Max Temp" to 72
+3. Set preset to "Away"
+
+**Expected:**
+- Thermostat accepts narrow range
+- Thermostat display shows 70–72°F
+
+### 8. Backward compatibility — no number entities configured
+
+**Steps:**
+1. Remove `vacation_days_number`, `vacation_min_temp_number`, `vacation_max_temp_number` from YAML
+2. Flash and set preset to "Away"
+
+**Expected:**
+- Vacation activates with defaults: 7 days, 60–80°F
+- Behavior identical to before this PR
+
+### 9. Cancel vacation from thermostat, verify HA updates
+
+**Steps:**
+1. With vacation active (started from HA), cancel from the physical thermostat
+2. Wait for a poll cycle
+
+**Expected:**
+- Climate entity updates to preset "Home"
+- Log: "3B04: vacation=off"
+
+### 10. Vacation activation blocked when Allow Control is OFF
+
+**Steps:**
+1. Turn Allow Control switch OFF
+2. Try to set preset to "Away"
+
+**Expected:**
+- No write sent to bus
+- Log: "Control blocked: Allow Control switch is OFF"
+- Climate entity remains on "Home"
+
+---
+
+## Failure Criteria
+
+If any of the following occur, **do not merge**:
+- Thermostat shows error codes or enters fault state
+- HVAC system starts/stops unexpectedly
+- NAK responses to vacation writes (check logs)
+- Communication lost after writes
+- Thermostat vacation display doesn't match configured values


### PR DESCRIPTION
## Summary

Add configurable vacation parameters via HA number entities, matching the physical thermostat's workflow: configure parameters → activate Away preset → cancel with Home preset.

## New Entities

### `vacation_days_number` (1–30 days)
- Duration for vacation mode
- Default: 7 days
- Entity category: CONFIG

### `vacation_min_temp_number` (40–99 °F)
- Minimum temperature during vacation
- Default: 60°F
- Entity category: CONFIG

### `vacation_max_temp_number` (40–99 °F)
- Maximum temperature during vacation
- Default: 80°F
- Entity category: CONFIG

## Behavior

- **Activation:** Set climate preset to "Away" → reads current values from number entities (or defaults) → sends 3B04 write
- **Cancellation:** Set climate preset to "Home" → sends 3B04 write with `vacation_active = 0`
- **Sync from thermostat:** When vacation is active, `parse_vacation()` updates the number entities with the thermostat's current values so HA always shows what's configured
- **Backward compatible:** If number entities aren't in YAML, defaults (7 days, 60–80°F) are used

## Changes

- **abcdesp.h** — `VacationDaysNumber`, `VacationMinTempNumber`, `VacationMaxTempNumber` classes; member pointers and setters
- **abcdesp.cpp** — Number `control()` callbacks; `parse_vacation()` now parses and publishes days/min/max to entities; `control()` reads from entities with fallback; `setup()` initializes defaults; `dump_config()` logs entities
- **__init__.py** — Config schemas and `to_code()` wiring for all three entities
- **abcdesp.yaml** — All three entities added
- **test_protocol.cpp** — 8 new tests: payload construction, boundaries, frame roundtrip, fallback logic, field parsing, deactivation
- **tests/test_vacation_hardware.md** — 10 hardware test cases
- **TODO.md** — Vacation parameters item struck out as done

## Testing
- [ ] CI: unit tests compile and pass with `g++ -std=c++17 -Wall -Wextra -Werror -DUNIT_TEST`
- [ ] Hardware testing per `tests/test_vacation_hardware.md`