### PR TITLE
docs: interactive test format with read-only tests first

### DIFF
--- a/tests/test_core_hardware.md
+++ b/tests/test_core_hardware.md
@@ -1,332 +1,33 @@
-# Hardware Testing Plan — Core Functions (Mode, Fan, Sensors, Communication)
+# Hardware Testing Plan — Core Functions
 
-These tests cover the base functionality of the component that is **not** exercised by the hold or vacation test plans. They **must be run on real Carrier Infinity equipment**.
-
+These tests cover the base functionality of the component. They **must be run on real Carrier Infinity equipment**.
 Monitor the thermostat display and ESPHome logs closely.
+
+> **How to use this file:** Copy into a GitHub Issue (checkboxes become interactive) or edit directly.
+> Mark each test PASS or FAIL, and fill in the Actual / Notes field with observations.
+> If any test fails, paste the filled-in section back to Copilot for diagnosis.
 
 ## Prerequisites
 
-- ESP32 connected to Carrier Infinity bus and communicating (Comms OK = true)
-- Allow Control switch: ON
-- ESPHome logs visible at DEBUG level
-- Home Assistant dashboard open showing all entities
-- System in a stable state (no active hold, no vacation)
+- [ ] ESP32 connected to Carrier Infinity bus and communicating (Comms OK = true)
+- [ ] ESPHome logs visible at DEBUG level
+- [ ] Home Assistant dashboard open showing all entities
+- [ ] System in a stable state (no active hold, no vacation)
+
+**Firmware version:** _______________
+**Date tested:** _______________
+**Tester:** _______________
 
 ---
 
-## A. Mode Changes
-
-### 1. Switch mode: Heat → Cool
-
-**Steps:**
-1. Set climate mode to Heat from HA (if not already)
-2. Wait for thermostat display to confirm Heat mode
-3. Switch climate mode to Cool from HA
-
-**Expected:**
-- Thermostat display shows Cool mode
-- Climate entity mode updates to `cool`
-- Action updates appropriately (idle or cooling depending on setpoint)
-
-### 2. Switch mode: Cool → Auto (Heat/Cool)
-
-**Steps:**
-1. With mode set to Cool, switch to Heat/Cool (Auto) from HA
-
-**Expected:**
-- Thermostat display shows Auto mode
-- Climate entity mode updates to `heat_cool`
-- Both heat and cool setpoints visible in HA
-
-### 3. Switch mode: Auto → Off
-
-**Steps:**
-1. With mode set to Auto, switch to Off from HA
-
-**Expected:**
-- Thermostat display shows system Off
-- Climate entity mode updates to `off`
-- Climate action → `off`
-- Blower should stop (may take a few seconds for fan-off delay)
-
-### 4. Switch mode: Off → Heat
-
-**Steps:**
-1. With mode Off, switch to Heat from HA
-
-**Expected:**
-- Thermostat display shows Heat mode
-- Climate entity updates to `heat`
-
-### 5. Mode change from thermostat reflects in HA
-
-**Steps:**
-1. Change mode on the physical thermostat (e.g., Heat → Cool)
-2. Wait for a poll cycle (~5 seconds)
-
-**Expected:**
-- Climate entity in HA updates to match thermostat selection
-- No writes sent by the ESP (read-only sync)
-
----
-
-## B. Fan Mode Changes
-
-### 6. Cycle fan modes: Auto → Low → Med → High → Auto
-
-**Steps:**
-1. Set fan mode to Low from HA; verify thermostat shows Low
-2. Set fan mode to Medium from HA; verify thermostat shows Med
-3. Set fan mode to High from HA; verify thermostat shows High
-4. Set fan mode to Auto from HA; verify thermostat shows Auto
-
-**Expected (each step):**
-- Thermostat display matches the selected fan speed
-- Climate entity `fan_mode` matches selection
-- If system is actively heating/cooling, blower speed changes audibly
-
-### 7. Fan mode change from thermostat reflects in HA
-
-**Steps:**
-1. Change fan mode on the physical thermostat
-2. Wait for a poll cycle (~5 seconds)
-
-**Expected:**
-- Climate entity `fan_mode` in HA updates to match
-
----
-
-## C. Temperature Sensors
-
-### 8. Current temperature reads correctly
-
-**Steps:**
-1. Compare thermostat display current temperature with the climate entity `current_temperature` in HA
-2. If you have an independent thermometer, cross-check
-
-**Expected:**
-- Values match within ±1°F (thermostat and HA show the same reading)
-
-### 9. Outdoor temperature sensor
-
-**Steps:**
-1. Check `sensor.abcdesp_outdoor_temperature` in HA
-2. Compare with the thermostat display (if thermostat shows outdoor temp) or weather forecast
-
-**Expected:**
-- Value is a plausible outdoor temperature for current conditions
-- Updates periodically (within ~15 seconds of a real change)
-- If no heat pump on the bus, this comes from the thermostat (3B02); if heat pump present, from 3E01
-
-### 10. Indoor humidity sensor
-
-**Steps:**
-1. Check `sensor.abcdesp_indoor_humidity` in HA
-2. Compare with the thermostat display humidity (if shown)
-
-**Expected:**
-- Value is in 0–100% range, plausible for current indoor conditions
-- Matches thermostat reading within ±1%
-
-### 11. HP coil temperature sensor
-
-**Requires:** Heat pump on the RS-485 bus.
-
-**Steps:**
-1. Check `sensor.abcdesp_hp_coil_temperature` in HA
-2. With system running in heat or cool, verify value is plausible:
-   - Heating: coil temp should be warmer than outdoor
-   - Cooling: coil temp should be colder than indoor
-
-**Expected:**
-- Value updates when system is actively running
-- Returns to near-ambient when system is idle
-
-### 12. Airflow CFM sensor
-
-**Requires:** Air handler on the RS-485 bus.
-
-**Steps:**
-1. Check `sensor.abcdesp_airflow_cfm` while system is idle → should be 0
-2. Trigger heating or cooling; wait for blower to start
-3. Verify CFM reads a plausible value (typically 400–2000 CFM depending on system size and fan speed)
-
-**Expected:**
-- 0 when blower is off
-- Positive value when blower is running
-- Higher values at higher fan speeds (Low < Med < High)
-
----
-
-## D. Stage Sensors
-
-### 13. Heat stage sensor
-
-**Requires:** Air handler on the RS-485 bus, system in Heat mode.
-
-**Steps:**
-1. Set mode to Heat with a setpoint well above current temperature
-2. Wait for system to call for heat
-
-**Expected:**
-- `sensor.abcdesp_heat_stage` updates from 0 to 1 (or higher for multi-stage)
-- `text_sensor.abcdesp_heat_stage_label` updates: "Off" → "Low" (→ "Med" → "High" if multi-stage)
-- When setpoint is satisfied and system stops, stage returns to 0 / "Off"
-
-### 14. HP stage sensor
-
-**Requires:** Heat pump on the RS-485 bus, system in Heat or Cool mode.
-
-**Steps:**
-1. Trigger a heating or cooling call
-2. Wait for heat pump to start
-
-**Expected:**
-- `sensor.abcdesp_hp_stage` updates from 0 to 1 (or 2 for high stage)
-- `text_sensor.abcdesp_hp_stage_label` updates: "Off" → "Low" (→ "High")
-- Stage returns to 0 / "Off" when call ends
-
----
-
-## E. Binary Sensors
-
-### 15. Blower running sensor
-
-**Steps:**
-1. With system idle, verify `binary_sensor.abcdesp_blower_running` = OFF
-2. Trigger a heating or cooling call
-3. Wait for blower to start (there may be a startup delay)
-
-**Expected:**
-- Sensor flips to ON when blower engages
-- Flips back to OFF when blower stops (may lag by fan-off delay, typically 60–90 seconds)
-
-### 16. Hold Active sensor
-
-**Steps:**
-1. Clear any holds; verify `binary_sensor.abcdesp_hold_active` = OFF
-2. Change a setpoint from HA (this should activate a hold)
-3. Verify sensor = ON
-4. Press "Clear Hold" button
-5. Verify sensor = OFF
-
-**Expected:**
-- State transitions match hold activation and clearing
-- Also changes if hold is set or cleared from the physical thermostat
-
-### 17. Communication OK sensor
-
-**Steps:**
-1. With system running normally, verify `binary_sensor.abcdesp_communication_ok` = ON
-2. (Optional/destructive) Disconnect the RS-485 data line briefly
-3. Wait >30 seconds
-
-**Expected:**
-- Sensor = ON during normal operation
-- Sensor → OFF if no response received within 30 seconds
-- Sensor → ON again when communication resumes
-
----
-
-## F. Climate Action State
-
-### 18. Action reflects current system activity
-
-**Steps:**
-1. Set mode to Off → action = `off`
-2. Set mode to Heat, setpoint well above current temp → wait for system to engage → action = `heating`
-3. Observe blower running after heat call stops → action = `fan` (if blower is on but not heating/cooling)
-4. After blower stops → action = `idle`
-5. Set mode to Cool, setpoint well below current temp → wait → action = `cooling`
-
-**Expected:**
-- Action state correctly tracks: off, heating, cooling, fan, idle
-- Transitions happen within one poll cycle (~5 seconds) of the physical state change
-
----
-
-## G. Setpoint Changes
-
-### 19. Change heat setpoint
-
-**Steps:**
-1. Set mode to Heat
-2. Change target temperature from HA (e.g., 70°F)
-
-**Expected:**
-- Thermostat display shows new setpoint
-- Climate entity `target_temperature` matches
-
-### 20. Change cool setpoint
-
-**Steps:**
-1. Set mode to Cool
-2. Change target temperature from HA (e.g., 76°F)
-
-**Expected:**
-- Thermostat display shows new setpoint
-- Climate entity `target_temperature` matches
-
-### 21. Change dual setpoints in Auto mode
-
-**Steps:**
-1. Set mode to Auto (Heat/Cool)
-2. Change heat setpoint (target_temperature_low) to 68°F
-3. Change cool setpoint (target_temperature_high) to 76°F
-
-**Expected:**
-- Thermostat display shows both setpoints
-- Climate entity shows correct `target_temperature_low` and `target_temperature_high`
-
-### 22. Setpoint change from thermostat reflects in HA
-
-**Steps:**
-1. Change a setpoint on the physical thermostat
-2. Wait for a poll cycle (~5 seconds)
-
-**Expected:**
-- Climate entity in HA updates to match the thermostat setpoint
-
----
-
-## H. Control Gating
-
-### 23. All writes blocked when Allow Control is OFF
-
-**Steps:**
-1. Turn Allow Control switch OFF
-2. Try each of the following from HA:
-   - Change mode
-   - Change fan mode
-   - Change setpoint
-   - Set Away preset
-3. Verify none produce bus writes
-
-**Expected (each attempt):**
-- No write sent to the bus
-- Log: "Control blocked: Allow Control switch is OFF"
-- Thermostat display unchanged
-- Read-only sensor updates continue normally
-
-### 24. Allow Control toggle
-
-**Steps:**
-1. Turn Allow Control OFF → verify writes blocked (test 23)
-2. Turn Allow Control ON → change a setpoint → verify write succeeds
-3. Reboot ESP32 → verify Allow Control defaults to OFF
-
-**Expected:**
-- Switch persists value across reboots (should restore last state, but defaults to OFF on first boot)
-- Writes only occur when switch is ON
-
----
-
-## I. Read-Only Mode (First Boot / Default State)
+## A. Read-Only Mode (First Boot / Default State)
 
 > Read-only mode is the **default state** on first boot — Allow Control is OFF.
-> These tests validate the full monitoring experience with zero writes to the bus.
+> Run this section first. No writes should be sent to the bus.
 
-### 27. First-boot read-only experience
+---
+
+### 1. First-boot read-only experience
 
 **Steps:**
 1. Flash a fresh ESP32 (or erase flash: ESPHome → Clean Build Files → Install)
@@ -340,25 +41,39 @@ Monitor the thermostat display and ESPHome logs closely.
 - Comms OK → ON
 - ESPHome logs show read requests only — no 0x0C (write) function codes
 
-### 28. All sensors update in read-only mode
+**Result:** &ensp; - [ ] PASS &ensp; - [ ] FAIL
+
+**Actual / Notes:**
+> &nbsp;
+
+---
+
+### 2. All sensors update in read-only mode
 
 **Steps:**
 1. Confirm Allow Control is OFF
 2. Observe the dashboard for 2–3 minutes
 
 **Expected (check each):**
-- `climate.abcdesp_hvac` — current temp, mode, fan mode, setpoints populated
-- `sensor.abcdesp_outdoor_temperature` — plausible value
-- `sensor.abcdesp_indoor_humidity` — plausible value (0–100%)
-- `binary_sensor.abcdesp_blower_running` — matches actual blower state
-- `sensor.abcdesp_airflow_cfm` — reads 0 when idle, positive when running (if air handler on bus)
-- `sensor.abcdesp_heat_stage` / `text_sensor.abcdesp_heat_stage_label` — updates if system is heating
-- `sensor.abcdesp_hp_coil_temperature` / `sensor.abcdesp_hp_stage` — updates if heat pump on bus
-- `binary_sensor.abcdesp_hold_active` — matches thermostat hold state
-- `sensor.abcdesp_hold_time_remaining` — shows countdown if timed hold active
-- `binary_sensor.abcdesp_communication_ok` — ON
+- [ ] `climate.abcdesp_hvac` — current temp, mode, fan mode, setpoints populated
+- [ ] `sensor.abcdesp_outdoor_temperature` — plausible value
+- [ ] `sensor.abcdesp_indoor_humidity` — plausible value (0–100%)
+- [ ] `binary_sensor.abcdesp_blower_running` — matches actual blower state
+- [ ] `sensor.abcdesp_airflow_cfm` — 0 when idle, positive when running (if air handler on bus)
+- [ ] `sensor.abcdesp_heat_stage` / `text_sensor.abcdesp_heat_stage_label` — updates if heating
+- [ ] `sensor.abcdesp_hp_coil_temperature` / `sensor.abcdesp_hp_stage` — updates if HP on bus
+- [ ] `binary_sensor.abcdesp_hold_active` — matches thermostat hold state
+- [ ] `sensor.abcdesp_hold_time_remaining` — shows countdown if timed hold active
+- [ ] `binary_sensor.abcdesp_communication_ok` — ON
 
-### 29. Thermostat-initiated mode change reflects in read-only mode
+**Result:** &ensp; - [ ] PASS &ensp; - [ ] FAIL
+
+**Actual / Notes:**
+> &nbsp;
+
+---
+
+### 3. Thermostat-initiated mode change reflects in read-only mode
 
 **Steps:**
 1. Confirm Allow Control is OFF
@@ -367,9 +82,16 @@ Monitor the thermostat display and ESPHome logs closely.
 
 **Expected:**
 - Climate entity in HA updates to match
-- No writes sent by the ESP (verify in logs — no "Sending write" messages)
+- No writes sent (verify in logs — no "Sending write" messages)
 
-### 30. Thermostat-initiated setpoint change reflects in read-only mode
+**Result:** &ensp; - [ ] PASS &ensp; - [ ] FAIL
+
+**Actual / Notes:**
+> &nbsp;
+
+---
+
+### 4. Thermostat-initiated setpoint change reflects in read-only mode
 
 **Steps:**
 1. Confirm Allow Control is OFF
@@ -380,7 +102,14 @@ Monitor the thermostat display and ESPHome logs closely.
 - Climate entity setpoint in HA updates to match thermostat
 - No bus writes
 
-### 31. Thermostat-initiated hold reflects in read-only mode
+**Result:** &ensp; - [ ] PASS &ensp; - [ ] FAIL
+
+**Actual / Notes:**
+> &nbsp;
+
+---
+
+### 5. Thermostat-initiated hold reflects in read-only mode
 
 **Steps:**
 1. Confirm Allow Control is OFF
@@ -392,7 +121,14 @@ Monitor the thermostat display and ESPHome logs closely.
 - `sensor.abcdesp_hold_time_remaining` updates if timed hold
 - No bus writes from ESP
 
-### 32. Thermostat-initiated vacation reflects in read-only mode
+**Result:** &ensp; - [ ] PASS &ensp; - [ ] FAIL
+
+**Actual / Notes:**
+> &nbsp;
+
+---
+
+### 6. Thermostat-initiated vacation reflects in read-only mode
 
 **Steps:**
 1. Confirm Allow Control is OFF
@@ -404,25 +140,39 @@ Monitor the thermostat display and ESPHome logs closely.
 - Vacation number entities update to reflect thermostat values (days, min/max temps)
 - No bus writes from ESP
 
-### 33. HA control attempts are silently blocked in read-only mode
+**Result:** &ensp; - [ ] PASS &ensp; - [ ] FAIL
+
+**Actual / Notes:**
+> &nbsp;
+
+---
+
+### 7. HA control attempts are silently blocked in read-only mode
 
 **Steps:**
 1. Confirm Allow Control is OFF
 2. Attempt each from HA:
-   - Change mode (e.g., Heat → Cool)
-   - Change fan mode
-   - Change setpoint
-   - Set preset to "Away"
-   - Press "Clear Hold"
-   - Set "Set Hold Time" to 60
+   - [ ] Change mode (e.g., Heat → Cool) — blocked?
+   - [ ] Change fan mode — blocked?
+   - [ ] Change setpoint — blocked?
+   - [ ] Set preset to "Away" — blocked?
+   - [ ] Press "Clear Hold" — blocked?
+   - [ ] Set "Set Hold Time" to 60 — blocked?
 
 **Expected (each attempt):**
 - No write sent to bus
 - Log: "Control blocked: Allow Control switch is OFF" (or specific variant)
 - Thermostat display unchanged
-- Entity state in HA does **not** change (climate stays at thermostat values)
+- Entity state in HA does **not** change
 
-### 34. Extended read-only stability (soak test)
+**Result:** &ensp; - [ ] PASS &ensp; - [ ] FAIL
+
+**Actual / Notes:**
+> &nbsp;
+
+---
+
+### 8. Extended read-only stability (soak test)
 
 **Steps:**
 1. Confirm Allow Control is OFF
@@ -434,13 +184,535 @@ Monitor the thermostat display and ESPHome logs closely.
 - Comms OK stays ON
 - No errors in ESPHome logs (WARN or ERROR level)
 - No writes sent (grep logs for "Sending write" — should be zero)
-- Climate entity stays in sync with thermostat through any mode/setpoint changes made at the thermostat
+- Climate entity stays in sync with thermostat through any changes made at the thermostat
+
+**Duration tested:** _______________ minutes
+
+**Result:** &ensp; - [ ] PASS &ensp; - [ ] FAIL
+
+**Actual / Notes:**
+> &nbsp;
+
+---
+
+## B. Control Gating
+
+> These tests validate the Allow Control switch. Turn it ON for the first time here.
+
+---
+
+### 9. Allow Control defaults OFF on first boot
+
+**Steps:**
+1. If not already tested in test 1, confirm `switch.abcdesp_allow_control` = OFF after a fresh flash
+
+**Result:** &ensp; - [ ] PASS &ensp; - [ ] FAIL
+
+**Actual / Notes:**
+> &nbsp;
+
+---
+
+### 10. Allow Control toggle enables writes
+
+**Steps:**
+1. Turn Allow Control ON
+2. Change a setpoint from HA
+3. Verify write succeeds (thermostat display updates)
+
+**Expected:**
+- Setpoint change appears on thermostat display
+- Log shows write sent to bus
+
+**Result:** &ensp; - [ ] PASS &ensp; - [ ] FAIL
+
+**Actual / Notes:**
+> &nbsp;
+
+---
+
+### 11. Allow Control persists across reboot
+
+**Steps:**
+1. Turn Allow Control ON
+2. Reboot ESP32 (HA → Developer Tools → Services → `esphome.abcdesp_restart`)
+3. After reconnect, check Allow Control state
+
+**Expected:**
+- Allow Control restores to ON (persisted via ESPHome preferences)
+
+**Result:** &ensp; - [ ] PASS &ensp; - [ ] FAIL
+
+**Actual / Notes:**
+> &nbsp;
+
+---
+
+## C. Mode Changes
+
+> Prerequisite: Allow Control = ON
+
+---
+
+### 12. Switch mode: Heat → Cool
+
+**Steps:**
+1. Set climate mode to Heat from HA (if not already)
+2. Wait for thermostat display to confirm Heat mode
+3. Switch climate mode to Cool from HA
+
+**Expected:**
+- Thermostat display shows Cool mode
+- Climate entity mode updates to `cool`
+- Action updates appropriately (idle or cooling depending on setpoint)
+
+**Result:** &ensp; - [ ] PASS &ensp; - [ ] FAIL
+
+**Actual / Notes:**
+> &nbsp;
+
+---
+
+### 13. Switch mode: Cool → Auto (Heat/Cool)
+
+**Steps:**
+1. With mode set to Cool, switch to Heat/Cool (Auto) from HA
+
+**Expected:**
+- Thermostat display shows Auto mode
+- Climate entity mode updates to `heat_cool`
+- Both heat and cool setpoints visible in HA
+
+**Result:** &ensp; - [ ] PASS &ensp; - [ ] FAIL
+
+**Actual / Notes:**
+> &nbsp;
+
+---
+
+### 14. Switch mode: Auto → Off
+
+**Steps:**
+1. With mode set to Auto, switch to Off from HA
+
+**Expected:**
+- Thermostat display shows system Off
+- Climate entity mode updates to `off`
+- Climate action → `off`
+- Blower should stop (may take a few seconds for fan-off delay)
+
+**Result:** &ensp; - [ ] PASS &ensp; - [ ] FAIL
+
+**Actual / Notes:**
+> &nbsp;
+
+---
+
+### 15. Switch mode: Off → Heat
+
+**Steps:**
+1. With mode Off, switch to Heat from HA
+
+**Expected:**
+- Thermostat display shows Heat mode
+- Climate entity updates to `heat`
+
+**Result:** &ensp; - [ ] PASS &ensp; - [ ] FAIL
+
+**Actual / Notes:**
+> &nbsp;
+
+---
+
+### 16. Mode change from thermostat reflects in HA
+
+**Steps:**
+1. Change mode on the physical thermostat (e.g., Heat → Cool)
+2. Wait for a poll cycle (~5 seconds)
+
+**Expected:**
+- Climate entity in HA updates to match thermostat selection
+- No writes sent by the ESP (read-only sync)
+
+**Result:** &ensp; - [ ] PASS &ensp; - [ ] FAIL
+
+**Actual / Notes:**
+> &nbsp;
+
+---
+
+## D. Fan Mode Changes
+
+---
+
+### 17. Cycle fan modes: Auto → Low → Med → High → Auto
+
+**Steps (check each):**
+- [ ] Set fan to Low → thermostat shows Low?
+- [ ] Set fan to Medium → thermostat shows Med?
+- [ ] Set fan to High → thermostat shows High?
+- [ ] Set fan to Auto → thermostat shows Auto?
+
+**Expected:**
+- Climate entity `fan_mode` matches selection at each step
+- If system is actively heating/cooling, blower speed changes audibly
+
+**Result:** &ensp; - [ ] PASS &ensp; - [ ] FAIL
+
+**Actual / Notes:**
+> &nbsp;
+
+---
+
+### 18. Fan mode change from thermostat reflects in HA
+
+**Steps:**
+1. Change fan mode on the physical thermostat
+2. Wait for a poll cycle (~5 seconds)
+
+**Expected:**
+- Climate entity `fan_mode` in HA updates to match
+
+**Result:** &ensp; - [ ] PASS &ensp; - [ ] FAIL
+
+**Actual / Notes:**
+> &nbsp;
+
+---
+
+## E. Setpoint Changes
+
+---
+
+### 19. Change heat setpoint
+
+**Steps:**
+1. Set mode to Heat
+2. Change target temperature from HA (e.g., 70°F)
+
+**Expected:**
+- Thermostat display shows new setpoint
+- Climate entity `target_temperature` matches
+
+**Setpoint sent:** ___°F &ensp; **Thermostat shows:** ___°F
+
+**Result:** &ensp; - [ ] PASS &ensp; - [ ] FAIL
+
+**Actual / Notes:**
+> &nbsp;
+
+---
+
+### 20. Change cool setpoint
+
+**Steps:**
+1. Set mode to Cool
+2. Change target temperature from HA (e.g., 76°F)
+
+**Expected:**
+- Thermostat display shows new setpoint
+- Climate entity `target_temperature` matches
+
+**Setpoint sent:** ___°F &ensp; **Thermostat shows:** ___°F
+
+**Result:** &ensp; - [ ] PASS &ensp; - [ ] FAIL
+
+**Actual / Notes:**
+> &nbsp;
+
+---
+
+### 21. Change dual setpoints in Auto mode
+
+**Steps:**
+1. Set mode to Auto (Heat/Cool)
+2. Change heat setpoint (target_temperature_low) to 68°F
+3. Change cool setpoint (target_temperature_high) to 76°F
+
+**Expected:**
+- Thermostat display shows both setpoints
+- Climate entity shows correct `target_temperature_low` and `target_temperature_high`
+
+**Heat sent:** ___°F → **Thermostat:** ___°F &ensp; **Cool sent:** ___°F → **Thermostat:** ___°F
+
+**Result:** &ensp; - [ ] PASS &ensp; - [ ] FAIL
+
+**Actual / Notes:**
+> &nbsp;
+
+---
+
+### 22. Setpoint change from thermostat reflects in HA
+
+**Steps:**
+1. Change a setpoint on the physical thermostat
+2. Wait for a poll cycle (~5 seconds)
+
+**Expected:**
+- Climate entity in HA updates to match the thermostat setpoint
+
+**Result:** &ensp; - [ ] PASS &ensp; - [ ] FAIL
+
+**Actual / Notes:**
+> &nbsp;
+
+---
+
+## F. Temperature Sensors
+
+---
+
+### 23. Current temperature reads correctly
+
+**Steps:**
+1. Compare thermostat display current temperature with the climate entity `current_temperature` in HA
+2. If you have an independent thermometer, cross-check
+
+**Expected:**
+- Values match within ±1°F
+
+**Thermostat:** ___°F &ensp; **HA:** ___°F &ensp; **Independent (if avail):** ___°F
+
+**Result:** &ensp; - [ ] PASS &ensp; - [ ] FAIL
+
+**Actual / Notes:**
+> &nbsp;
+
+---
+
+### 24. Outdoor temperature sensor
+
+**Steps:**
+1. Check `sensor.abcdesp_outdoor_temperature` in HA
+2. Compare with the thermostat display (if shown) or weather forecast
+
+**Expected:**
+- Value is plausible for current conditions
+- Updates periodically (within ~15 seconds of a real change)
+
+**HA value:** ___°F &ensp; **Reference (tstat/weather):** ___°F
+
+**Result:** &ensp; - [ ] PASS &ensp; - [ ] FAIL
+
+**Actual / Notes:**
+> &nbsp;
+
+---
+
+### 25. Indoor humidity sensor
+
+**Steps:**
+1. Check `sensor.abcdesp_indoor_humidity` in HA
+2. Compare with the thermostat display humidity (if shown)
+
+**Expected:**
+- Value is in 0–100% range, plausible for current indoor conditions
+
+**HA value:** ___% &ensp; **Thermostat:** ___%
+
+**Result:** &ensp; - [ ] PASS &ensp; - [ ] FAIL
+
+**Actual / Notes:**
+> &nbsp;
+
+---
+
+### 26. HP coil temperature sensor
+
+**Requires:** Heat pump on the RS-485 bus.
+
+- [ ] **N/A** — no heat pump on bus (skip this test)
+
+**Steps:**
+1. Check `sensor.abcdesp_hp_coil_temperature` in HA
+2. With system running in heat or cool, verify value is plausible:
+   - Heating: coil temp should be warmer than outdoor
+   - Cooling: coil temp should be colder than indoor
+
+**Expected:**
+- Value updates when system is actively running
+- Returns to near-ambient when system is idle
+
+**HA value (running):** ___°F &ensp; **HA value (idle):** ___°F
+
+**Result:** &ensp; - [ ] PASS &ensp; - [ ] FAIL
+
+**Actual / Notes:**
+> &nbsp;
+
+---
+
+### 27. Airflow CFM sensor
+
+**Requires:** Air handler on the RS-485 bus.
+
+- [ ] **N/A** — no air handler on bus (skip this test)
+
+**Steps:**
+1. Check `sensor.abcdesp_airflow_cfm` while system is idle → should be 0
+2. Trigger heating or cooling; wait for blower to start
+3. Verify CFM reads a plausible value (typically 400–2000 CFM)
+
+**Expected:**
+- 0 when blower is off
+- Positive value when blower is running
+- Higher values at higher fan speeds (Low < Med < High)
+
+**CFM idle:** ___ &ensp; **CFM running:** ___ &ensp; **Fan speed:** ___
+
+**Result:** &ensp; - [ ] PASS &ensp; - [ ] FAIL
+
+**Actual / Notes:**
+> &nbsp;
+
+---
+
+## G. Stage Sensors
+
+---
+
+### 28. Heat stage sensor
+
+**Requires:** Air handler on the RS-485 bus, system in Heat mode.
+
+- [ ] **N/A** — no air handler on bus (skip this test)
+
+**Steps:**
+1. Set mode to Heat with a setpoint well above current temperature
+2. Wait for system to call for heat
+
+**Expected:**
+- `sensor.abcdesp_heat_stage` updates from 0 to 1 (or higher for multi-stage)
+- `text_sensor.abcdesp_heat_stage_label` updates: "Off" → "Low" (→ "Med" → "High")
+- When setpoint is satisfied and system stops, stage returns to 0 / "Off"
+
+**Stage observed:** ___ &ensp; **Label observed:** _______________
+
+**Result:** &ensp; - [ ] PASS &ensp; - [ ] FAIL
+
+**Actual / Notes:**
+> &nbsp;
+
+---
+
+### 29. HP stage sensor
+
+**Requires:** Heat pump on the RS-485 bus, system in Heat or Cool mode.
+
+- [ ] **N/A** — no heat pump on bus (skip this test)
+
+**Steps:**
+1. Trigger a heating or cooling call
+2. Wait for heat pump to start
+
+**Expected:**
+- `sensor.abcdesp_hp_stage` updates from 0 to 1 (or 2 for high stage)
+- `text_sensor.abcdesp_hp_stage_label` updates: "Off" → "Low" (→ "High")
+- Stage returns to 0 / "Off" when call ends
+
+**Stage observed:** ___ &ensp; **Label observed:** _______________
+
+**Result:** &ensp; - [ ] PASS &ensp; - [ ] FAIL
+
+**Actual / Notes:**
+> &nbsp;
+
+---
+
+## H. Binary Sensors
+
+---
+
+### 30. Blower running sensor
+
+**Steps:**
+1. With system idle, verify `binary_sensor.abcdesp_blower_running` = OFF
+2. Trigger a heating or cooling call
+3. Wait for blower to start (there may be a startup delay)
+
+**Expected:**
+- Sensor flips to ON when blower engages
+- Flips back to OFF when blower stops (may lag by fan-off delay, typically 60–90 seconds)
+
+**Result:** &ensp; - [ ] PASS &ensp; - [ ] FAIL
+
+**Actual / Notes:**
+> &nbsp;
+
+---
+
+### 31. Hold Active sensor
+
+**Steps:**
+1. Clear any holds; verify `binary_sensor.abcdesp_hold_active` = OFF
+2. Change a setpoint from HA (this should activate a hold)
+3. Verify sensor = ON
+4. Press "Clear Hold" button
+5. Verify sensor = OFF
+
+**Expected:**
+- State transitions match hold activation and clearing
+- Also changes if hold is set or cleared from the physical thermostat
+
+**Result:** &ensp; - [ ] PASS &ensp; - [ ] FAIL
+
+**Actual / Notes:**
+> &nbsp;
+
+---
+
+### 32. Communication OK sensor
+
+**Steps:**
+1. With system running normally, verify `binary_sensor.abcdesp_communication_ok` = ON
+2. (Optional/destructive) Disconnect the RS-485 data line briefly
+3. Wait >30 seconds
+
+**Expected:**
+- Sensor = ON during normal operation
+- Sensor → OFF if no response received within 30 seconds
+- Sensor → ON again when communication resumes
+
+- [ ] **Skipped** disconnect test (destructive)
+
+**Result:** &ensp; - [ ] PASS &ensp; - [ ] FAIL
+
+**Actual / Notes:**
+> &nbsp;
+
+---
+
+## I. Climate Action State
+
+---
+
+### 33. Action reflects current system activity
+
+**Steps (check each transition):**
+- [ ] Set mode to Off → action = `off`
+- [ ] Set mode to Heat, setpoint well above current temp → action = `heating`
+- [ ] Observe blower running after heat call stops → action = `fan`
+- [ ] After blower stops → action = `idle`
+- [ ] Set mode to Cool, setpoint well below current temp → action = `cooling`
+
+**Expected:**
+- Action state correctly tracks: off, heating, cooling, fan, idle
+- Transitions happen within one poll cycle (~5 seconds)
+
+**Result:** &ensp; - [ ] PASS &ensp; - [ ] FAIL
+
+**Actual / Notes:**
+> &nbsp;
 
 ---
 
 ## J. Communication Resilience
 
-### 35. Recovery after brief bus interruption
+---
+
+### 34. Recovery after brief bus interruption
+
+- [ ] **Skipped** (destructive — requires disconnecting RS-485)
 
 **Steps:**
 1. Briefly disconnect then reconnect the RS-485 data lines (< 5 seconds)
@@ -451,10 +723,17 @@ Monitor the thermostat display and ESPHome logs closely.
 - Polling resumes normally after reconnection
 - No error codes on thermostat
 
-### 36. CRC failure logging
+**Result:** &ensp; - [ ] PASS &ensp; - [ ] FAIL
+
+**Actual / Notes:**
+> &nbsp;
+
+---
+
+### 35. CRC failure logging
 
 **Steps:**
-1. Monitor ESPHome logs at DEBUG level during normal operation
+1. Monitor ESPHome logs at DEBUG level during normal operation for ~5 minutes
 2. Check for any CRC failure messages
 
 **Expected:**
@@ -462,7 +741,30 @@ Monitor the thermostat display and ESPHome logs closely.
 - After 10 consecutive CRC failures, an ERROR-level log appears
 - System continues operating despite CRC failures (frames are just discarded)
 
+**CRC failures observed:** ___ in ___ minutes
+
+**Result:** &ensp; - [ ] PASS &ensp; - [ ] FAIL
+
+**Actual / Notes:**
+> &nbsp;
+
 ---
+
+## Summary
+
+| Section | Tests | Passed | Failed | Skipped |
+|---------|-------|--------|--------|---------|
+| A. Read-Only Mode | 1–8 | | | |
+| B. Control Gating | 9–11 | | | |
+| C. Mode Changes | 12–16 | | | |
+| D. Fan Mode Changes | 17–18 | | | |
+| E. Setpoint Changes | 19–22 | | | |
+| F. Temperature Sensors | 23–27 | | | |
+| G. Stage Sensors | 28–29 | | | |
+| H. Binary Sensors | 30–32 | | | |
+| I. Climate Action | 33 | | | |
+| J. Communication | 34–35 | | | |
+| **TOTAL** | **35** | | | |
 
 ## Failure Criteria
 

--- a/tests/test_hold_hardware.md
+++ b/tests/test_hold_hardware.md
@@ -1,19 +1,25 @@
 # Hardware Testing Plan — Runtime Hold Duration
 
-These tests **must be run on real Carrier Infinity equipment** after merging to verify correct behavior.
+These tests **must be run on real Carrier Infinity equipment** to verify hold duration behavior.
 The HVAC bus is sensitive to incorrect writes — monitor the thermostat display and ESPHome logs closely.
+
+> **How to use this file:** Copy into a GitHub Issue (checkboxes become interactive) or edit directly.
+> Mark each test PASS or FAIL, and fill in the Actual / Notes field with observations.
+> If any test fails, paste the filled-in section back to Copilot for diagnosis.
 
 ## Prerequisites
 
-- ESP32 connected to Carrier Infinity bus and communicating (Comms OK = true)
-- Allow Control switch: ON
-- System in heat or cool mode (not off)
-- ESPHome logs visible at DEBUG level
-- Home Assistant dashboard open showing the climate entity
+- [ ] ESP32 connected to Carrier Infinity bus and communicating (Comms OK = true)
+- [ ] Allow Control switch: ON
+- [ ] System in heat or cool mode (not off)
+- [ ] ESPHome logs visible at DEBUG level
+- [ ] Home Assistant dashboard open showing the climate entity
+
+**Firmware version:** _______________
+**Date tested:** _______________
+**Tester:** _______________
 
 ---
-
-## Test Cases
 
 ### 1. Setpoint change with hold_duration_number configured
 
@@ -28,6 +34,15 @@ The HVAC bus is sensitive to incorrect writes — monitor the thermostat display
 - Thermostat display shows timed hold with ~120 minutes
 - Log: "Setting native timed hold for 120 minutes"
 
+**Hold Time Remaining observed:** ___ min
+
+**Result:** &ensp; - [ ] PASS &ensp; - [ ] FAIL
+
+**Actual / Notes:**
+> &nbsp;
+
+---
+
 ### 2. Adjust active hold time via Set Hold Time number
 
 **Steps:**
@@ -39,6 +54,15 @@ The HVAC bus is sensitive to incorrect writes — monitor the thermostat display
 - Hold Time Remaining updates to ≈ 60 min
 - Thermostat display shows updated countdown
 - Log: "Adjusting hold to 60 minutes"
+
+**Hold Time Remaining observed:** ___ min
+
+**Result:** &ensp; - [ ] PASS &ensp; - [ ] FAIL
+
+**Actual / Notes:**
+> &nbsp;
+
+---
 
 ### 3. Make active hold permanent via Set Hold Time
 
@@ -52,6 +76,13 @@ The HVAC bus is sensitive to incorrect writes — monitor the thermostat display
 - Thermostat display shows permanent hold (no countdown)
 - Log: "Adjusting hold to permanent"
 
+**Result:** &ensp; - [ ] PASS &ensp; - [ ] FAIL
+
+**Actual / Notes:**
+> &nbsp;
+
+---
+
 ### 4. Adjust hold blocked when no hold active
 
 **Steps:**
@@ -64,6 +95,13 @@ The HVAC bus is sensitive to incorrect writes — monitor the thermostat display
 - Log: "Adjust hold blocked: no active hold on zone 1"
 - Thermostat display unchanged
 
+**Result:** &ensp; - [ ] PASS &ensp; - [ ] FAIL
+
+**Actual / Notes:**
+> &nbsp;
+
+---
+
 ### 5. Adjust hold blocked when Allow Control is OFF
 
 **Steps:**
@@ -75,6 +113,13 @@ The HVAC bus is sensitive to incorrect writes — monitor the thermostat display
 - No write sent to the bus
 - Log: "Adjust hold blocked: Allow Control switch is OFF"
 
+**Result:** &ensp; - [ ] PASS &ensp; - [ ] FAIL
+
+**Actual / Notes:**
+> &nbsp;
+
+---
+
 ### 6. Change default duration and verify next setpoint change uses it
 
 **Steps:**
@@ -84,6 +129,15 @@ The HVAC bus is sensitive to incorrect writes — monitor the thermostat display
 **Expected:**
 - New hold has ≈ 30 min countdown
 - Log: "Setting native timed hold for 30 minutes"
+
+**Hold Time Remaining observed:** ___ min
+
+**Result:** &ensp; - [ ] PASS &ensp; - [ ] FAIL
+
+**Actual / Notes:**
+> &nbsp;
+
+---
 
 ### 7. Set Hold Duration to 0 (permanent) and change setpoint
 
@@ -96,17 +150,35 @@ The HVAC bus is sensitive to incorrect writes — monitor the thermostat display
 - Hold Time Remaining stays 0
 - Thermostat display shows permanent hold
 
+**Result:** &ensp; - [ ] PASS &ensp; - [ ] FAIL
+
+**Actual / Notes:**
+> &nbsp;
+
+---
+
 ### 8. Reboot persistence of Hold Duration
 
 **Steps:**
 1. Set Hold Duration number to 45
-2. Reboot the ESP32 (HA → Developer Tools → Services → esphome.abcdesp_restart)
+2. Reboot the ESP32 (HA → Developer Tools → Services → `esphome.abcdesp_restart`)
 3. After reconnect, check Hold Duration number value
 
 **Expected:**
-- Hold Duration number restores to 45 (restore_value: true)
+- Hold Duration number restores to 45
+
+**Hold Duration after reboot:** ___
+
+**Result:** &ensp; - [ ] PASS &ensp; - [ ] FAIL
+
+**Actual / Notes:**
+> &nbsp;
+
+---
 
 ### 9. Backward compatibility — no number entities configured
+
+- [ ] **Skipped** (requires YAML change and reflash)
 
 **Steps:**
 1. Remove `hold_duration_number` and `set_hold_time_number` from YAML
@@ -114,9 +186,16 @@ The HVAC bus is sensitive to incorrect writes — monitor the thermostat display
 3. Flash and change a setpoint
 
 **Expected:**
-- Behavior identical to before this PR
+- Behavior identical to before this feature
 - Timed hold uses compile-time 120 minute value
 - No errors in logs about missing entities
+
+**Result:** &ensp; - [ ] PASS &ensp; - [ ] FAIL
+
+**Actual / Notes:**
+> &nbsp;
+
+---
 
 ### 10. Hold expiry via ESP fallback timer
 
@@ -130,11 +209,34 @@ The HVAC bus is sensitive to incorrect writes — monitor the thermostat display
 - Hold Active → OFF
 - Log: "Temporary hold expired after 2 minutes — clearing"
 
+**Time until hold cleared:** ___ min
+
+**Result:** &ensp; - [ ] PASS &ensp; - [ ] FAIL
+
+**Actual / Notes:**
+> &nbsp;
+
 ---
+
+## Summary
+
+| Test | Description | Result |
+|------|-------------|--------|
+| 1 | Setpoint with hold duration | |
+| 2 | Adjust active hold time | |
+| 3 | Convert to permanent hold | |
+| 4 | Adjust blocked (no hold) | |
+| 5 | Adjust blocked (Allow Control OFF) | |
+| 6 | Change default duration | |
+| 7 | Permanent hold (duration = 0) | |
+| 8 | Reboot persistence | |
+| 9 | Backward compatibility | |
+| 10 | Hold expiry timer | |
+| **TOTAL** | **10 tests** | |
 
 ## Failure Criteria
 
-If any of the following occur, **do not merge**:
+If any of the following occur, **stop testing and investigate**:
 - Thermostat shows error codes or enters fault state
 - HVAC system starts/stops unexpectedly
 - NAK responses to adjust_hold writes (check logs)

--- a/tests/test_vacation_hardware.md
+++ b/tests/test_vacation_hardware.md
@@ -1,19 +1,25 @@
 # Hardware Testing Plan — Configurable Vacation Parameters
 
-These tests **must be run on real Carrier Infinity equipment** after merging.
+These tests **must be run on real Carrier Infinity equipment**.
 Monitor the thermostat display and ESPHome logs closely.
+
+> **How to use this file:** Copy into a GitHub Issue (checkboxes become interactive) or edit directly.
+> Mark each test PASS or FAIL, and fill in the Actual / Notes field with observations.
+> If any test fails, paste the filled-in section back to Copilot for diagnosis.
 
 ## Prerequisites
 
-- ESP32 connected to Carrier Infinity bus and communicating (Comms OK = true)
-- Allow Control switch: ON
-- System NOT in vacation mode at start
-- ESPHome logs visible at DEBUG level
-- Home Assistant dashboard open showing the climate entity
+- [ ] ESP32 connected to Carrier Infinity bus and communicating (Comms OK = true)
+- [ ] Allow Control switch: ON
+- [ ] System NOT in vacation mode at start
+- [ ] ESPHome logs visible at DEBUG level
+- [ ] Home Assistant dashboard open showing the climate entity
+
+**Firmware version:** _______________
+**Date tested:** _______________
+**Tester:** _______________
 
 ---
-
-## Test Cases
 
 ### 1. Activate vacation with default parameters
 
@@ -27,6 +33,15 @@ Monitor the thermostat display and ESPHome logs closely.
 - Climate entity shows preset "Away"
 - Log: "Activating vacation mode (7 days, 60-80F)"
 
+**Thermostat shows:** ___ days, ___–___°F
+
+**Result:** &ensp; - [ ] PASS &ensp; - [ ] FAIL
+
+**Actual / Notes:**
+> &nbsp;
+
+---
+
 ### 2. Cancel vacation from HA
 
 **Steps:**
@@ -36,6 +51,13 @@ Monitor the thermostat display and ESPHome logs closely.
 - Thermostat exits vacation mode
 - Climate entity shows preset "Home"
 - Log: "Deactivating vacation mode"
+
+**Result:** &ensp; - [ ] PASS &ensp; - [ ] FAIL
+
+**Actual / Notes:**
+> &nbsp;
+
+---
 
 ### 3. Configure custom parameters then activate
 
@@ -50,6 +72,15 @@ Monitor the thermostat display and ESPHome logs closely.
 - Thermostat display shows: 14 days, 55–85°F
 - Log: "Activating vacation mode (14 days, 55-85F)"
 
+**Thermostat shows:** ___ days, ___–___°F
+
+**Result:** &ensp; - [ ] PASS &ensp; - [ ] FAIL
+
+**Actual / Notes:**
+> &nbsp;
+
+---
+
 ### 4. Verify number entities update from thermostat
 
 **Steps:**
@@ -59,6 +90,15 @@ Monitor the thermostat display and ESPHome logs closely.
 **Expected:**
 - Vacation Days, Vacation Min Temp, Vacation Max Temp number entities update to match thermostat values
 - Climate entity shows preset "Away"
+
+**Thermostat set:** ___ days, ___–___°F &ensp; **HA shows:** ___ days, ___–___°F
+
+**Result:** &ensp; - [ ] PASS &ensp; - [ ] FAIL
+
+**Actual / Notes:**
+> &nbsp;
+
+---
 
 ### 5. Activate vacation with 1 day (minimum)
 
@@ -71,6 +111,15 @@ Monitor the thermostat display and ESPHome logs closely.
 - Thermostat shows 1 day vacation
 - Log: "Activating vacation mode (1 days, 60-80F)"
 
+**Thermostat shows:** ___ day(s)
+
+**Result:** &ensp; - [ ] PASS &ensp; - [ ] FAIL
+
+**Actual / Notes:**
+> &nbsp;
+
+---
+
 ### 6. Activate vacation with 30 days (maximum)
 
 **Steps:**
@@ -80,6 +129,15 @@ Monitor the thermostat display and ESPHome logs closely.
 **Expected:**
 - Thermostat shows 30 day vacation
 - No NAK responses
+
+**Thermostat shows:** ___ day(s)
+
+**Result:** &ensp; - [ ] PASS &ensp; - [ ] FAIL
+
+**Actual / Notes:**
+> &nbsp;
+
+---
 
 ### 7. Narrow temperature range
 
@@ -92,7 +150,18 @@ Monitor the thermostat display and ESPHome logs closely.
 - Thermostat accepts narrow range
 - Thermostat display shows 70–72°F
 
+**Thermostat shows:** ___–___°F
+
+**Result:** &ensp; - [ ] PASS &ensp; - [ ] FAIL
+
+**Actual / Notes:**
+> &nbsp;
+
+---
+
 ### 8. Backward compatibility — no number entities configured
+
+- [ ] **Skipped** (requires YAML change and reflash)
 
 **Steps:**
 1. Remove `vacation_days_number`, `vacation_min_temp_number`, `vacation_max_temp_number` from YAML
@@ -100,7 +169,14 @@ Monitor the thermostat display and ESPHome logs closely.
 
 **Expected:**
 - Vacation activates with defaults: 7 days, 60–80°F
-- Behavior identical to before this PR
+- Behavior identical to before this feature
+
+**Result:** &ensp; - [ ] PASS &ensp; - [ ] FAIL
+
+**Actual / Notes:**
+> &nbsp;
+
+---
 
 ### 9. Cancel vacation from thermostat, verify HA updates
 
@@ -111,6 +187,13 @@ Monitor the thermostat display and ESPHome logs closely.
 **Expected:**
 - Climate entity updates to preset "Home"
 - Log: "3B04: vacation=off"
+
+**Result:** &ensp; - [ ] PASS &ensp; - [ ] FAIL
+
+**Actual / Notes:**
+> &nbsp;
+
+---
 
 ### 10. Vacation activation blocked when Allow Control is OFF
 
@@ -123,11 +206,32 @@ Monitor the thermostat display and ESPHome logs closely.
 - Log: "Control blocked: Allow Control switch is OFF"
 - Climate entity remains on "Home"
 
+**Result:** &ensp; - [ ] PASS &ensp; - [ ] FAIL
+
+**Actual / Notes:**
+> &nbsp;
+
 ---
+
+## Summary
+
+| Test | Description | Result |
+|------|-------------|--------|
+| 1 | Default vacation activation | |
+| 2 | Cancel from HA | |
+| 3 | Custom parameters | |
+| 4 | Thermostat-initiated sync | |
+| 5 | Minimum 1 day | |
+| 6 | Maximum 30 days | |
+| 7 | Narrow temp range | |
+| 8 | Backward compatibility | |
+| 9 | Cancel from thermostat | |
+| 10 | Blocked (Allow Control OFF) | |
+| **TOTAL** | **10 tests** | |
 
 ## Failure Criteria
 
-If any of the following occur, **do not merge**:
+If any of the following occur, **stop testing and investigate**:
 - Thermostat shows error codes or enters fault state
 - HVAC system starts/stops unexpectedly
 - NAK responses to vacation writes (check logs)


### PR DESCRIPTION
## Summary

Reformat all three hardware test plans for interactive use and reorder core tests so read-only mode comes first.

## Changes

### All three files:
- **PASS / FAIL checkboxes** on every test — clickable in GitHub Issues
- **Actual / Notes** blockquote field for writing observations
- **Fill-in fields** for measured values (temps, times, CFM, stages, etc.)
- **N/A / Skipped checkboxes** for optional or destructive tests
- **Prerequisites checklist** with firmware version, date, and tester fields
- **Summary table** at the bottom for quick pass/fail overview

### `test_core_hardware.md` — reordered:
| Section | Tests | What it covers |
|---------|-------|----------------|
| **A. Read-Only Mode** (was I) | 1–8 | First boot, sensors, thermostat-initiated changes, soak test |
| **B. Control Gating** (was H) | 9–11 | Allow Control default, toggle, persistence |
| C. Mode Changes | 12–16 | Heat/Cool/Auto/Off from HA and thermostat |
| D. Fan Modes | 17–18 | Auto/Low/Med/High cycling |
| E. Setpoints | 19–22 | Heat, cool, dual auto, thermostat-initiated |
| F. Temperature Sensors | 23–27 | Current, outdoor, humidity, HP coil, CFM |
| G. Stage Sensors | 28–29 | Heat stage, HP stage |
| H. Binary Sensors | 30–32 | Blower, hold active, comms OK |
| I. Climate Action | 33 | off/heating/cooling/fan/idle tracking |
| J. Communication | 34–35 | Bus interruption, CRC logging |

### Workflow
1. Copy a test file into a GitHub Issue for clickable checkboxes, or edit the .md directly
2. Fill in PASS/FAIL and observations as you test
3. If a test fails, paste the filled-in section back to Copilot for diagnosis