### PR TITLE
Fix: register component so ESPHome calls setup/loop/dump_config

### DIFF
--- a/components/abcdesp/__init__.py
+++ b/components/abcdesp/__init__.py
@@ -168,6 +168,7 @@ CONFIG_SCHEMA = (
 
 async def to_code(config):
     var = await climate.new_climate(config)
+    await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
 
     if CONF_FLOW_PIN in config:


### PR DESCRIPTION
## Problem

The `AbcdEspComponent` was never registered as an ESPHome `Component` — only as a climate entity. `climate.new_climate()` registers the object with Home Assistant but does **not** call `cg.register_component()`, so ESPHome never invoked:

- `setup()` — no bus initialization, no poll timer start
- `loop()` — no UART reading, no frame parsing, no polling
- `dump_config()` — no `[C][abcdesp:...]` log output

This meant the component appeared functional (number entities like Vacation Days worked since they're registered independently) but **no bus communication occurred** even with RS-485 wires connected.

## Fix

Add `await cg.register_component(var, config)` in `to_code()` after `climate.new_climate()`.

## Testing

Discovered during first hardware test — device booted, WiFi connected, HA entities appeared, but zero bus activity and no abcdesp log output despite DEBUG level logging and A/B wires connected.