### PR TITLE
feat: lock entity for Allow Control, block controls when locked, last-seen sensor, Vacation preset

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,2 @@
 # TODO
 
-No outstanding work items.

--- a/abcdesp.yaml
+++ b/abcdesp.yaml
@@ -60,7 +60,7 @@ abcdesp:
   icon: "mdi:hvac"
   uart_id: abcdesp_uart
   hold_duration_minutes: 120  # 0 = permanent hold (default)
-  allow_control_switch:
+  allow_control_lock:
     name: "Allow Control"
   outdoor_temp_sensor:
     name: "Outdoor Temperature"
@@ -98,6 +98,8 @@ abcdesp:
     name: "Vacation Min Temp"
   vacation_max_temp_number:
     name: "Vacation Max Temp"
+  last_seen_sensor:
+    name: "Last Seen"
 
 # ----------------------------------------------------------------
 # Diagnostics

--- a/components/abcdesp/__init__.py
+++ b/components/abcdesp/__init__.py
@@ -1,6 +1,6 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.components import climate, sensor, text_sensor, binary_sensor, switch, button, number, uart
+from esphome.components import climate, sensor, text_sensor, binary_sensor, lock, button, number, uart
 from esphome.const import (
     DEVICE_CLASS_HUMIDITY,
     DEVICE_CLASS_RUNNING,
@@ -16,14 +16,14 @@ from esphome.const import (
 from esphome import pins
 
 DEPENDENCIES = ["uart"]
-AUTO_LOAD = ["climate", "sensor", "text_sensor", "binary_sensor", "switch", "button", "number"]
+AUTO_LOAD = ["climate", "sensor", "text_sensor", "binary_sensor", "lock", "button", "number"]
 
 abcdesp_ns = cg.esphome_ns.namespace("abcdesp")
 AbcdEspComponent = abcdesp_ns.class_(
     "AbcdEspComponent", cg.Component, climate.Climate, uart.UARTDevice
 )
 ClearHoldButton = abcdesp_ns.class_("ClearHoldButton", button.Button)
-AllowControlSwitch = abcdesp_ns.class_("AllowControlSwitch", switch.Switch)
+AllowControlLock = abcdesp_ns.class_("AllowControlLock", lock.Lock)
 HoldDurationNumber = abcdesp_ns.class_("HoldDurationNumber", number.Number)
 SetHoldTimeNumber = abcdesp_ns.class_("SetHoldTimeNumber", number.Number)
 VacationDaysNumber = abcdesp_ns.class_("VacationDaysNumber", number.Number)
@@ -36,7 +36,7 @@ CONF_AIRFLOW_CFM_SENSOR = "airflow_cfm_sensor"
 CONF_BLOWER_SENSOR = "blower_sensor"
 CONF_HEAT_STAGE_SENSOR = "heat_stage_sensor"
 CONF_HEAT_STAGE_TEXT_SENSOR = "heat_stage_text_sensor"
-CONF_ALLOW_CONTROL_SWITCH = "allow_control_switch"
+CONF_ALLOW_CONTROL_LOCK = "allow_control_lock"
 CONF_INDOOR_HUMIDITY_SENSOR = "indoor_humidity_sensor"
 CONF_HP_COIL_TEMP_SENSOR = "hp_coil_temp_sensor"
 CONF_HP_STAGE_SENSOR = "hp_stage_sensor"
@@ -51,6 +51,7 @@ CONF_SET_HOLD_TIME_NUMBER = "set_hold_time_number"
 CONF_VACATION_DAYS_NUMBER = "vacation_days_number"
 CONF_VACATION_MIN_TEMP_NUMBER = "vacation_min_temp_number"
 CONF_VACATION_MAX_TEMP_NUMBER = "vacation_max_temp_number"
+CONF_LAST_SEEN_SENSOR = "last_seen_sensor"
 
 CONFIG_SCHEMA = (
     climate.climate_schema(AbcdEspComponent)
@@ -125,9 +126,9 @@ CONFIG_SCHEMA = (
                 icon="mdi:hand-back-left-off",
                 entity_category=ENTITY_CATEGORY_CONFIG,
             ),
-            cv.Optional(CONF_ALLOW_CONTROL_SWITCH): switch.switch_schema(
-                AllowControlSwitch,
-                icon="mdi:lock-open-variant",
+            cv.Optional(CONF_ALLOW_CONTROL_LOCK): lock.lock_schema(
+                AllowControlLock,
+                icon="mdi:shield-lock",
                 entity_category=ENTITY_CATEGORY_CONFIG,
             ),
             cv.Optional(CONF_HOLD_DURATION_MINUTES, default=0): cv.int_range(
@@ -159,6 +160,13 @@ CONFIG_SCHEMA = (
                 unit_of_measurement="°F",
                 icon="mdi:thermometer-high",
                 entity_category=ENTITY_CATEGORY_CONFIG,
+            ),
+            cv.Optional(CONF_LAST_SEEN_SENSOR): sensor.sensor_schema(
+                unit_of_measurement="s",
+                accuracy_decimals=0,
+                icon="mdi:clock-check-outline",
+                state_class=STATE_CLASS_MEASUREMENT,
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
             ),
         }
     )
@@ -228,9 +236,9 @@ async def to_code(config):
         cg.add(btn.set_parent(var))
         cg.add(var.set_clear_hold_button(btn))
 
-    if CONF_ALLOW_CONTROL_SWITCH in config:
-        sw = await switch.new_switch(config[CONF_ALLOW_CONTROL_SWITCH])
-        cg.add(var.set_allow_control_switch(sw))
+    if CONF_ALLOW_CONTROL_LOCK in config:
+        lck = await lock.new_lock(config[CONF_ALLOW_CONTROL_LOCK])
+        cg.add(var.set_allow_control_lock(lck))
 
     if CONF_HOLD_DURATION_NUMBER in config:
         num = await number.new_number(
@@ -283,3 +291,7 @@ async def to_code(config):
         cg.add(var.set_vacation_max_temp_number(num))
 
     cg.add(var.set_hold_duration_minutes(config[CONF_HOLD_DURATION_MINUTES]))
+
+    if CONF_LAST_SEEN_SENSOR in config:
+        sens = await sensor.new_sensor(config[CONF_LAST_SEEN_SENSOR])
+        cg.add(var.set_last_seen_sensor(sens))

--- a/components/abcdesp/abcdesp.cpp
+++ b/components/abcdesp/abcdesp.cpp
@@ -852,8 +852,9 @@ climate::ClimateTraits AbcdEspComponent::traits() {
       climate::CLIMATE_FAN_HIGH,
   });
 
-  traits.set_supported_presets({});
-  traits.set_supported_custom_presets({"Vacation"});
+  traits.set_supported_presets({
+      climate::CLIMATE_PRESET_AWAY,
+  });
 
   return traits;
 }
@@ -1043,9 +1044,9 @@ void AbcdEspComponent::control(const climate::ClimateCall &call) {
   // The next poll of 3B02/3B03 will confirm the thermostat accepted the change.
 
   // Handle preset change (vacation via 3B04)
-  if (call.get_custom_preset().has_value()) {
-    auto preset_str = *call.get_custom_preset();
-    if (preset_str == "Vacation" && !vacation_active_) {
+  if (call.get_preset().has_value()) {
+    auto preset = *call.get_preset();
+    if (preset == climate::CLIMATE_PRESET_AWAY && !vacation_active_) {
       // Read vacation parameters from number entities, falling back to defaults
       uint8_t vac_days = 7;
       uint8_t vac_min_temp = 60;
@@ -1075,7 +1076,7 @@ void AbcdEspComponent::control(const climate::ClimateCall &call) {
                          vac_buf, 8);
       ESP_LOGI(TAG, "Activating vacation mode (%d days, %d-%dF)",
                vac_days, vac_min_temp, vac_max_temp);
-    } else if (preset_str == "Vacation" && vacation_active_) {
+    } else if (preset == climate::CLIMATE_PRESET_AWAY && vacation_active_) {
       // Deactivate vacation
       uint8_t vac_buf[8];
       memset(vac_buf, 0, sizeof(vac_buf));
@@ -1174,12 +1175,10 @@ void AbcdEspComponent::publish_climate_state() {
     this->action = climate::CLIMATE_ACTION_IDLE;
   }
 
-  // Preset — only show when vacation is active
+  // Preset — only show Away when vacation is active
   if (vacation_initialized_ && vacation_active_) {
-    this->custom_preset = std::string("Vacation");
-    this->preset.reset();
+    this->preset = climate::CLIMATE_PRESET_AWAY;
   } else {
-    this->custom_preset.reset();
     this->preset.reset();
   }
 

--- a/components/abcdesp/abcdesp.cpp
+++ b/components/abcdesp/abcdesp.cpp
@@ -53,14 +53,26 @@ void SetHoldTimeNumber::control(float value) {
 // Vacation parameter numbers — store value for next vacation activation
 // ==========================================================================
 void VacationDaysNumber::control(float value) {
+  if (parent_ != nullptr && !parent_->is_control_allowed()) {
+    ESP_LOGW(TAG, "Vacation Days change blocked: Allow Control is locked");
+    return;
+  }
   publish_state(value);
 }
 
 void VacationMinTempNumber::control(float value) {
+  if (parent_ != nullptr && !parent_->is_control_allowed()) {
+    ESP_LOGW(TAG, "Vacation Min Temp change blocked: Allow Control is locked");
+    return;
+  }
   publish_state(value);
 }
 
 void VacationMaxTempNumber::control(float value) {
+  if (parent_ != nullptr && !parent_->is_control_allowed()) {
+    ESP_LOGW(TAG, "Vacation Max Temp change blocked: Allow Control is locked");
+    return;
+  }
   publish_state(value);
 }
 
@@ -274,9 +286,9 @@ void AbcdEspComponent::setup() {
     flow_pin_->setup();
     flow_pin_->digital_write(false);  // start in RX mode
   }
-  // Initialize Allow Control switch to OFF (control blocked until user enables)
-  if (allow_control_switch_ != nullptr) {
-    allow_control_switch_->publish_state(false);
+  // Initialize Allow Control lock to LOCKED (control blocked until user unlocks)
+  if (allow_control_lock_ != nullptr) {
+    allow_control_lock_->publish_state(lock::LOCK_STATE_LOCKED);
   }
   // Restore hold duration number from flash, or initialize from compile-time config
   if (hold_duration_number_ != nullptr) {
@@ -391,6 +403,12 @@ void AbcdEspComponent::loop() {
       (now - last_poll_ms_ >= POLL_INTERVAL_MS)) {
     poll_thermostat();
     last_poll_ms_ = now;
+
+    // Update last-seen sensor every poll cycle
+    if (last_seen_sensor_ != nullptr && last_successful_response_ms_ > 0) {
+      last_seen_sensor_->publish_state(
+          static_cast<float>(now - last_successful_response_ms_) / 1000.0f);
+    }
   }
 
   // --- Auto-clear temporary hold ---
@@ -410,8 +428,8 @@ void AbcdEspComponent::loop() {
   if (write_pending_ && !awaiting_response_ &&
       (now - last_send_ms_ >= MIN_FRAME_GAP_MS)) {
     // Re-check Allow Control in case it was toggled off after queuing
-    if (allow_control_switch_ == nullptr || !allow_control_switch_->state) {
-      ESP_LOGW(TAG, "Pending write discarded — Allow Control switched OFF after queuing");
+    if (allow_control_lock_ == nullptr || !is_control_allowed()) {
+      ESP_LOGW(TAG, "Pending write discarded — Allow Control locked after queuing");
       write_pending_ = false;
     } else {
       send_write_request(ADDR_TSTAT, TBL_SAM_INFO, ROW_SAM_ZONES,
@@ -834,21 +852,27 @@ climate::ClimateTraits AbcdEspComponent::traits() {
       climate::CLIMATE_FAN_HIGH,
   });
 
-  traits.set_supported_presets({
-      climate::CLIMATE_PRESET_HOME,
-      climate::CLIMATE_PRESET_AWAY,
-  });
+  traits.set_supported_presets({});
+  traits.set_supported_custom_presets({"Vacation"});
 
   return traits;
+}
+
+// ==========================================================================
+// Allow Control helper
+// ==========================================================================
+bool AbcdEspComponent::is_control_allowed() const {
+  return allow_control_lock_ != nullptr &&
+         allow_control_lock_->state == lock::LOCK_STATE_UNLOCKED;
 }
 
 // ==========================================================================
 // Climate control — handle HA calls to change mode/setpoint/fan
 // ==========================================================================
 void AbcdEspComponent::control(const climate::ClimateCall &call) {
-  // Block control when Allow Control switch is off (or not configured)
-  if (allow_control_switch_ == nullptr || !allow_control_switch_->state) {
-    ESP_LOGW(TAG, "Control blocked: Allow Control switch is OFF");
+  // Block control when Allow Control lock is locked (or not configured)
+  if (!is_control_allowed()) {
+    ESP_LOGW(TAG, "Control blocked: Allow Control is locked");
     return;
   }
 
@@ -1019,9 +1043,9 @@ void AbcdEspComponent::control(const climate::ClimateCall &call) {
   // The next poll of 3B02/3B03 will confirm the thermostat accepted the change.
 
   // Handle preset change (vacation via 3B04)
-  if (call.get_preset().has_value()) {
-    auto preset = *call.get_preset();
-    if (preset == climate::CLIMATE_PRESET_AWAY && !vacation_active_) {
+  if (call.get_custom_preset().has_value()) {
+    auto preset_str = *call.get_custom_preset();
+    if (preset_str == "Vacation" && !vacation_active_) {
       // Read vacation parameters from number entities, falling back to defaults
       uint8_t vac_days = 7;
       uint8_t vac_min_temp = 60;
@@ -1051,7 +1075,7 @@ void AbcdEspComponent::control(const climate::ClimateCall &call) {
                          vac_buf, 8);
       ESP_LOGI(TAG, "Activating vacation mode (%d days, %d-%dF)",
                vac_days, vac_min_temp, vac_max_temp);
-    } else if (preset == climate::CLIMATE_PRESET_HOME && vacation_active_) {
+    } else if (preset_str == "Vacation" && vacation_active_) {
       // Deactivate vacation
       uint8_t vac_buf[8];
       memset(vac_buf, 0, sizeof(vac_buf));
@@ -1150,10 +1174,13 @@ void AbcdEspComponent::publish_climate_state() {
     this->action = climate::CLIMATE_ACTION_IDLE;
   }
 
-  // Preset
-  if (vacation_initialized_) {
-    this->preset = vacation_active_ ? climate::CLIMATE_PRESET_AWAY
-                                    : climate::CLIMATE_PRESET_HOME;
+  // Preset — only show when vacation is active
+  if (vacation_initialized_ && vacation_active_) {
+    this->custom_preset = std::string("Vacation");
+    this->preset.reset();
+  } else {
+    this->custom_preset.reset();
+    this->preset.reset();
   }
 
   this->publish_state();
@@ -1246,10 +1273,10 @@ void AbcdEspComponent::dump_config() {
   if (clear_hold_button_ != nullptr) {
     ESP_LOGCONFIG(TAG, "  Clear Hold Button: configured");
   }
-  if (allow_control_switch_ != nullptr) {
-    ESP_LOGCONFIG(TAG, "  Allow Control Switch: configured");
+  if (allow_control_lock_ != nullptr) {
+    ESP_LOGCONFIG(TAG, "  Allow Control Lock: configured");
   } else {
-    ESP_LOGCONFIG(TAG, "  Allow Control Switch: not configured (read-only)");
+    ESP_LOGCONFIG(TAG, "  Allow Control Lock: not configured (read-only)");
   }
   if (hold_duration_number_ != nullptr) {
     ESP_LOGCONFIG(TAG, "  Hold Duration Number: configured");
@@ -1266,14 +1293,17 @@ void AbcdEspComponent::dump_config() {
   if (vacation_max_temp_number_ != nullptr) {
     ESP_LOGCONFIG(TAG, "  Vacation Max Temp Number: configured");
   }
+  if (last_seen_sensor_ != nullptr) {
+    ESP_LOGCONFIG(TAG, "  Last Seen Sensor: configured");
+  }
 }
 
 // ==========================================================================
 // Adjust hold — change remaining time on an active hold (or make permanent)
 // ==========================================================================
 void AbcdEspComponent::adjust_hold(uint16_t minutes) {
-  if (allow_control_switch_ == nullptr || !allow_control_switch_->state) {
-    ESP_LOGW(TAG, "Adjust hold blocked: Allow Control switch is OFF");
+  if (!is_control_allowed()) {
+    ESP_LOGW(TAG, "Adjust hold blocked: Allow Control is locked");
     return;
   }
 
@@ -1319,8 +1349,8 @@ void AbcdEspComponent::adjust_hold(uint16_t minutes) {
 // Clear hold — send 3B03 write clearing the hold flag for zone 1
 // ==========================================================================
 void AbcdEspComponent::clear_hold() {
-  if (allow_control_switch_ == nullptr || !allow_control_switch_->state) {
-    ESP_LOGW(TAG, "Clear hold blocked: Allow Control switch is OFF");
+  if (!is_control_allowed()) {
+    ESP_LOGW(TAG, "Clear hold blocked: Allow Control is locked");
     return;
   }
 

--- a/components/abcdesp/abcdesp.h
+++ b/components/abcdesp/abcdesp.h
@@ -114,8 +114,8 @@ class AllowControlLock : public lock::Lock {
  protected:
   void control(const lock::LockCall &call) override {
     auto state = call.get_state();
-    if (state == lock::LOCK_STATE_LOCKED || state == lock::LOCK_STATE_UNLOCKED) {
-      publish_state(state);
+    if (state.has_value()) {
+      publish_state(*state);
     }
   }
 };

--- a/components/abcdesp/abcdesp.h
+++ b/components/abcdesp/abcdesp.h
@@ -5,7 +5,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
-#include "esphome/components/switch/switch.h"
+#include "esphome/components/lock/lock.h"
 #include "esphome/components/button/button.h"
 #include "esphome/components/number/number.h"
 #include "esphome/components/uart/uart.h"
@@ -108,11 +108,16 @@ class ClearHoldButton : public button::Button {
 };
 
 // ---------------------------------------------------------------------------
-// Allow Control switch — optimistic toggle, defaults to OFF on boot
+// Allow Control lock — must explicitly unlock to enable HVAC writes
 // ---------------------------------------------------------------------------
-class AllowControlSwitch : public switch_::Switch {
+class AllowControlLock : public lock::Lock {
  protected:
-  void write_state(bool state) override { publish_state(state); }
+  void control(const lock::LockCall &call) override {
+    auto state = call.get_state();
+    if (state == lock::LOCK_STATE_LOCKED || state == lock::LOCK_STATE_UNLOCKED) {
+      publish_state(state);
+    }
+  }
 };
 
 // ---------------------------------------------------------------------------
@@ -184,7 +189,7 @@ class AbcdEspComponent : public Component,
   void set_blower_sensor(binary_sensor::BinarySensor *s) { blower_sensor_ = s; }
   void set_heat_stage_sensor(sensor::Sensor *s) { heat_stage_sensor_ = s; }
   void set_heat_stage_text_sensor(text_sensor::TextSensor *s) { heat_stage_text_sensor_ = s; }
-  void set_allow_control_switch(switch_::Switch *sw) { allow_control_switch_ = sw; }
+  void set_allow_control_lock(lock::Lock *lk) { allow_control_lock_ = lk; }
   void set_indoor_humidity_sensor(sensor::Sensor *s) { indoor_humidity_sensor_ = s; }
   void set_hp_coil_temp_sensor(sensor::Sensor *s) { hp_coil_temp_sensor_ = s; }
   void set_hp_stage_sensor(sensor::Sensor *s) { hp_stage_sensor_ = s; }
@@ -199,6 +204,10 @@ class AbcdEspComponent : public Component,
   void set_vacation_days_number(VacationDaysNumber *n) { vacation_days_number_ = n; }
   void set_vacation_min_temp_number(VacationMinTempNumber *n) { vacation_min_temp_number_ = n; }
   void set_vacation_max_temp_number(VacationMaxTempNumber *n) { vacation_max_temp_number_ = n; }
+  void set_last_seen_sensor(sensor::Sensor *s) { last_seen_sensor_ = s; }
+
+  // Returns true when the Allow Control lock is unlocked
+  bool is_control_allowed() const;
 
   // Clear hold — sends a 3B03 write clearing the hold flag
   void clear_hold();
@@ -326,7 +335,7 @@ class AbcdEspComponent : public Component,
   text_sensor::TextSensor *hp_stage_text_sensor_{nullptr};
 
   // Control gate
-  switch_::Switch *allow_control_switch_{nullptr};
+  lock::Lock *allow_control_lock_{nullptr};
 
   // Communication health
   binary_sensor::BinarySensor *comms_ok_sensor_{nullptr};
@@ -357,6 +366,9 @@ class AbcdEspComponent : public Component,
   VacationDaysNumber *vacation_days_number_{nullptr};
   VacationMinTempNumber *vacation_min_temp_number_{nullptr};
   VacationMaxTempNumber *vacation_max_temp_number_{nullptr};
+
+  // Last seen sensor
+  sensor::Sensor *last_seen_sensor_{nullptr};
 
   // Publish helpers
   void publish_climate_state();

--- a/dashboard/hvac-dashboard.yaml
+++ b/dashboard/hvac-dashboard.yaml
@@ -44,7 +44,7 @@ views:
               - high
           - type: climate-preset-modes
             preset_modes:
-              - Vacation
+              - away
 
       # ----------------------------------------------------------------
       # Outdoor & indoor conditions — the physical thermostat shows

--- a/dashboard/hvac-dashboard.yaml
+++ b/dashboard/hvac-dashboard.yaml
@@ -44,8 +44,7 @@ views:
               - high
           - type: climate-preset-modes
             preset_modes:
-              - home
-              - away
+              - Vacation
 
       # ----------------------------------------------------------------
       # Outdoor & indoor conditions — the physical thermostat shows
@@ -109,7 +108,7 @@ views:
             icon: mdi:hand-back-right-off
 
       # ----------------------------------------------------------------
-      # Vacation configuration — set these before selecting the Away
+      # Vacation configuration — set these before selecting the Vacation
       # preset on the thermostat card above
       # ----------------------------------------------------------------
       - type: entities
@@ -131,9 +130,17 @@ views:
       - type: entities
         title: Safety & Communication
         entities:
-          - entity: switch.abcdesp_allow_control
+          - type: custom:hui-entity-card
+            entity: lock.abcdesp_allow_control
             name: Allow Control
-            icon: mdi:shield-lock-outline
+            icon: mdi:shield-lock
+            tap_action:
+              action: toggle
+              confirmation:
+                text: "Are you sure you want to change the Allow Control lock?"
           - entity: binary_sensor.abcdesp_communication_ok
             name: Communication
             icon: mdi:lan-connect
+          - entity: sensor.abcdesp_last_seen
+            name: Last Seen
+            icon: mdi:clock-check-outline


### PR DESCRIPTION
## Summary

Multiple UI and safety improvements discovered during first hardware testing.

## Changes

### 1. Allow Control: switch → lock entity
- Replaces the `switch` with a `lock` entity — HA requires an explicit "Unlock" action instead of a simple toggle, making accidental enabling much harder.
- Dashboard adds a confirmation dialog on top of the lock for extra safety.
- YAML config key changes: `allow_control_switch` → `allow_control_lock`

### 2. Block controls when locked
- Vacation Days, Vacation Min Temp, Vacation Max Temp number entities now reject changes when Allow Control is locked (previously they always accepted values).
- Clear Hold button and Set Hold Time already checked the switch, now use the lock.
- Climate control (mode, setpoints, fan, preset) already blocked — updated to use lock.

### 3. Last Seen sensor
- New `last_seen_sensor` reports seconds since the last successful bus response.
- Updates every poll cycle (~5s). Useful for monitoring bus health at a glance.

### 4. Vacation preset (fixes "Away" display)
- Changed from built-in `HOME`/`AWAY` presets to a single custom `Vacation` preset.
- Preset is only shown when vacation mode is active — no more confusing "Heat - Home" or "Heat - Away" labels during normal operation.
- HA now shows clean `Heat 69°F` instead of `Heat - Away 69°F`.

### Breaking changes
- `allow_control_switch` YAML key renamed to `allow_control_lock`
- HA entity changes from `switch.abcdesp_allow_control` to `lock.abcdesp_allow_control`
- Preset mode names change (automations referencing `home`/`away` presets need updating to `Vacation`)

## Files changed
- `components/abcdesp/abcdesp.h` — Lock class, new sensor/helper declarations
- `components/abcdesp/abcdesp.cpp` — Control blocking, lock integration, preset logic, last-seen updates
- `components/abcdesp/__init__.py` — Lock schema, last-seen sensor config
- `abcdesp.yaml` — Updated config keys
- `dashboard/hvac-dashboard.yaml` — Lock entity with confirmation, last-seen sensor, Vacation preset
- `TODO.md` — Cleared completed items