### PR TITLE
Replace Away preset with vacation buttons

### DIFF
--- a/abcdesp.yaml
+++ b/abcdesp.yaml
@@ -99,6 +99,10 @@ abcdesp:
     name: "Vacation Min Temp"
   vacation_max_temp_number:
     name: "Vacation Max Temp"
+  activate_vacation_button:
+    name: "Activate Vacation"
+  cancel_vacation_button:
+    name: "Cancel Vacation"
   last_seen_sensor:
     name: "Last Seen"
 

--- a/components/abcdesp/__init__.py
+++ b/components/abcdesp/__init__.py
@@ -23,6 +23,8 @@ AbcdEspComponent = abcdesp_ns.class_(
     "AbcdEspComponent", cg.Component, climate.Climate, uart.UARTDevice
 )
 ClearHoldButton = abcdesp_ns.class_("ClearHoldButton", button.Button)
+ActivateVacationButton = abcdesp_ns.class_("ActivateVacationButton", button.Button)
+CancelVacationButton = abcdesp_ns.class_("CancelVacationButton", button.Button)
 AllowControlLock = abcdesp_ns.class_("AllowControlLock", lock.Lock)
 HoldDurationNumber = abcdesp_ns.class_("HoldDurationNumber", number.Number)
 SetHoldTimeNumber = abcdesp_ns.class_("SetHoldTimeNumber", number.Number)
@@ -51,6 +53,8 @@ CONF_SET_HOLD_TIME_NUMBER = "set_hold_time_number"
 CONF_VACATION_DAYS_NUMBER = "vacation_days_number"
 CONF_VACATION_MIN_TEMP_NUMBER = "vacation_min_temp_number"
 CONF_VACATION_MAX_TEMP_NUMBER = "vacation_max_temp_number"
+CONF_ACTIVATE_VACATION_BUTTON = "activate_vacation_button"
+CONF_CANCEL_VACATION_BUTTON = "cancel_vacation_button"
 CONF_LAST_SEEN_SENSOR = "last_seen_sensor"
 
 CONFIG_SCHEMA = (
@@ -159,6 +163,16 @@ CONFIG_SCHEMA = (
                 VacationMaxTempNumber,
                 unit_of_measurement="°F",
                 icon="mdi:thermometer-high",
+                entity_category=ENTITY_CATEGORY_CONFIG,
+            ),
+            cv.Optional(CONF_ACTIVATE_VACATION_BUTTON): button.button_schema(
+                ActivateVacationButton,
+                icon="mdi:airplane-takeoff",
+                entity_category=ENTITY_CATEGORY_CONFIG,
+            ),
+            cv.Optional(CONF_CANCEL_VACATION_BUTTON): button.button_schema(
+                CancelVacationButton,
+                icon="mdi:airplane-off",
                 entity_category=ENTITY_CATEGORY_CONFIG,
             ),
             cv.Optional(CONF_LAST_SEEN_SENSOR): sensor.sensor_schema(
@@ -289,6 +303,16 @@ async def to_code(config):
         )
         cg.add(num.set_parent(var))
         cg.add(var.set_vacation_max_temp_number(num))
+
+    if CONF_ACTIVATE_VACATION_BUTTON in config:
+        btn = await button.new_button(config[CONF_ACTIVATE_VACATION_BUTTON])
+        cg.add(btn.set_parent(var))
+        cg.add(var.set_activate_vacation_button(btn))
+
+    if CONF_CANCEL_VACATION_BUTTON in config:
+        btn = await button.new_button(config[CONF_CANCEL_VACATION_BUTTON])
+        cg.add(btn.set_parent(var))
+        cg.add(var.set_cancel_vacation_button(btn))
 
     cg.add(var.set_hold_duration_minutes(config[CONF_HOLD_DURATION_MINUTES]))
 

--- a/components/abcdesp/abcdesp.cpp
+++ b/components/abcdesp/abcdesp.cpp
@@ -17,6 +17,18 @@ void ClearHoldButton::press_action() {
   }
 }
 
+void ActivateVacationButton::press_action() {
+  if (parent_ != nullptr) {
+    parent_->activate_vacation();
+  }
+}
+
+void CancelVacationButton::press_action() {
+  if (parent_ != nullptr) {
+    parent_->cancel_vacation();
+  }
+}
+
 // ==========================================================================
 // HoldDurationNumber — update default hold duration at runtime
 // ==========================================================================
@@ -852,9 +864,8 @@ climate::ClimateTraits AbcdEspComponent::traits() {
       climate::CLIMATE_FAN_HIGH,
   });
 
-  traits.set_supported_presets({
-      climate::CLIMATE_PRESET_AWAY,
-  });
+  // No presets declared — Away is set dynamically only when vacation is active.
+  // This prevents the thermostat card from always showing an "Away" button.
 
   return traits;
 }
@@ -1042,50 +1053,6 @@ void AbcdEspComponent::control(const climate::ClimateCall &call) {
 
   // Note: state is NOT optimistically updated here.
   // The next poll of 3B02/3B03 will confirm the thermostat accepted the change.
-
-  // Handle preset change (vacation via 3B04)
-  if (call.get_preset().has_value()) {
-    auto preset = *call.get_preset();
-    if (preset == climate::CLIMATE_PRESET_AWAY && !vacation_active_) {
-      // Read vacation parameters from number entities, falling back to defaults
-      uint8_t vac_days = 7;
-      uint8_t vac_min_temp = 60;
-      uint8_t vac_max_temp = 80;
-
-      if (vacation_days_number_ != nullptr && !std::isnan(vacation_days_number_->state)) {
-        vac_days = static_cast<uint8_t>(vacation_days_number_->state);
-      }
-      if (vacation_min_temp_number_ != nullptr && !std::isnan(vacation_min_temp_number_->state)) {
-        vac_min_temp = static_cast<uint8_t>(vacation_min_temp_number_->state);
-      }
-      if (vacation_max_temp_number_ != nullptr && !std::isnan(vacation_max_temp_number_->state)) {
-        vac_max_temp = static_cast<uint8_t>(vacation_max_temp_number_->state);
-      }
-
-      uint16_t days_x7 = static_cast<uint16_t>(vac_days) * 7;
-      uint8_t vac_buf[8];
-      vac_buf[0] = 0x01;                       // vacation_active = 1
-      vac_buf[1] = (days_x7 >> 8) & 0xFF;      // days*7 high byte
-      vac_buf[2] = days_x7 & 0xFF;             // days*7 low byte
-      vac_buf[3] = vac_min_temp;               // min temp °F
-      vac_buf[4] = vac_max_temp;               // max temp °F
-      vac_buf[5] = 15;                         // min humidity
-      vac_buf[6] = 60;                         // max humidity
-      vac_buf[7] = FAN_AUTO;
-      send_write_request(ADDR_TSTAT, TBL_SAM_INFO, ROW_SAM_VACATION,
-                         vac_buf, 8);
-      ESP_LOGI(TAG, "Activating vacation mode (%d days, %d-%dF)",
-               vac_days, vac_min_temp, vac_max_temp);
-    } else if (preset == climate::CLIMATE_PRESET_AWAY && vacation_active_) {
-      // Deactivate vacation
-      uint8_t vac_buf[8];
-      memset(vac_buf, 0, sizeof(vac_buf));
-      vac_buf[0] = 0x00;  // vacation_active = 0
-      send_write_request(ADDR_TSTAT, TBL_SAM_INFO, ROW_SAM_VACATION,
-                         vac_buf, 8);
-      ESP_LOGI(TAG, "Deactivating vacation mode");
-    }
-  }
 }
 
 // ==========================================================================
@@ -1372,6 +1339,73 @@ void AbcdEspComponent::clear_hold() {
   hold_set_ms_ = 0;  // cancel any pending ESP-managed auto-clear
 
   ESP_LOGI(TAG, "Queued clear hold for zone 1");
+}
+
+// ==========================================================================
+// Activate vacation — reads days/min/max from number entities, sends 3B04
+// ==========================================================================
+void AbcdEspComponent::activate_vacation() {
+  if (!is_control_allowed()) {
+    ESP_LOGW(TAG, "Activate vacation blocked: Allow Control is locked");
+    return;
+  }
+
+  if (vacation_active_) {
+    ESP_LOGW(TAG, "Vacation is already active");
+    return;
+  }
+
+  // Read vacation parameters from number entities, falling back to defaults
+  uint8_t vac_days = 7;
+  uint8_t vac_min_temp = 60;
+  uint8_t vac_max_temp = 80;
+
+  if (vacation_days_number_ != nullptr && !std::isnan(vacation_days_number_->state)) {
+    vac_days = static_cast<uint8_t>(vacation_days_number_->state);
+  }
+  if (vacation_min_temp_number_ != nullptr && !std::isnan(vacation_min_temp_number_->state)) {
+    vac_min_temp = static_cast<uint8_t>(vacation_min_temp_number_->state);
+  }
+  if (vacation_max_temp_number_ != nullptr && !std::isnan(vacation_max_temp_number_->state)) {
+    vac_max_temp = static_cast<uint8_t>(vacation_max_temp_number_->state);
+  }
+
+  uint16_t days_x7 = static_cast<uint16_t>(vac_days) * 7;
+  uint8_t vac_buf[8];
+  vac_buf[0] = 0x01;                       // vacation_active = 1
+  vac_buf[1] = (days_x7 >> 8) & 0xFF;      // days*7 high byte
+  vac_buf[2] = days_x7 & 0xFF;             // days*7 low byte
+  vac_buf[3] = vac_min_temp;               // min temp °F
+  vac_buf[4] = vac_max_temp;               // max temp °F
+  vac_buf[5] = 15;                         // min humidity
+  vac_buf[6] = 60;                         // max humidity
+  vac_buf[7] = FAN_AUTO;
+  send_write_request(ADDR_TSTAT, TBL_SAM_INFO, ROW_SAM_VACATION,
+                     vac_buf, 8);
+  ESP_LOGI(TAG, "Activating vacation mode (%d days, %d-%dF)",
+           vac_days, vac_min_temp, vac_max_temp);
+}
+
+// ==========================================================================
+// Cancel vacation — sends 3B04 with vacation_active = 0
+// ==========================================================================
+void AbcdEspComponent::cancel_vacation() {
+  if (!is_control_allowed()) {
+    ESP_LOGW(TAG, "Cancel vacation blocked: Allow Control is locked");
+    return;
+  }
+
+  if (!vacation_active_) {
+    ESP_LOGW(TAG, "Vacation is not active");
+    return;
+  }
+
+  uint8_t vac_buf[8];
+  memset(vac_buf, 0, sizeof(vac_buf));
+  vac_buf[0] = 0x00;  // vacation_active = 0
+  send_write_request(ADDR_TSTAT, TBL_SAM_INFO, ROW_SAM_VACATION,
+                     vac_buf, 8);
+  ESP_LOGI(TAG, "Deactivating vacation mode");
 }
 
 }  // namespace abcdesp

--- a/components/abcdesp/abcdesp.h
+++ b/components/abcdesp/abcdesp.h
@@ -108,6 +108,30 @@ class ClearHoldButton : public button::Button {
 };
 
 // ---------------------------------------------------------------------------
+// Activate Vacation button
+// ---------------------------------------------------------------------------
+class ActivateVacationButton : public button::Button {
+ public:
+  void set_parent(AbcdEspComponent *parent) { parent_ = parent; }
+
+ protected:
+  void press_action() override;
+  AbcdEspComponent *parent_{nullptr};
+};
+
+// ---------------------------------------------------------------------------
+// Cancel Vacation button
+// ---------------------------------------------------------------------------
+class CancelVacationButton : public button::Button {
+ public:
+  void set_parent(AbcdEspComponent *parent) { parent_ = parent; }
+
+ protected:
+  void press_action() override;
+  AbcdEspComponent *parent_{nullptr};
+};
+
+// ---------------------------------------------------------------------------
 // Allow Control lock — must explicitly unlock to enable HVAC writes
 // ---------------------------------------------------------------------------
 class AllowControlLock : public lock::Lock {
@@ -204,6 +228,8 @@ class AbcdEspComponent : public Component,
   void set_vacation_days_number(VacationDaysNumber *n) { vacation_days_number_ = n; }
   void set_vacation_min_temp_number(VacationMinTempNumber *n) { vacation_min_temp_number_ = n; }
   void set_vacation_max_temp_number(VacationMaxTempNumber *n) { vacation_max_temp_number_ = n; }
+  void set_activate_vacation_button(ActivateVacationButton *b) { activate_vacation_button_ = b; }
+  void set_cancel_vacation_button(CancelVacationButton *b) { cancel_vacation_button_ = b; }
   void set_last_seen_sensor(sensor::Sensor *s) { last_seen_sensor_ = s; }
 
   // Returns true when the Allow Control lock is unlocked
@@ -211,6 +237,10 @@ class AbcdEspComponent : public Component,
 
   // Clear hold — sends a 3B03 write clearing the hold flag
   void clear_hold();
+
+  // Vacation control
+  void activate_vacation();
+  void cancel_vacation();
 
   // Adjust hold — change remaining time on an active hold
   void adjust_hold(uint16_t minutes);
@@ -357,6 +387,10 @@ class AbcdEspComponent : public Component,
 
   // Clear hold button
   ClearHoldButton *clear_hold_button_{nullptr};
+
+  // Vacation buttons
+  ActivateVacationButton *activate_vacation_button_{nullptr};
+  CancelVacationButton *cancel_vacation_button_{nullptr};
 
   // Runtime hold duration number entities
   HoldDurationNumber *hold_duration_number_{nullptr};

--- a/dashboard/hvac-dashboard.yaml
+++ b/dashboard/hvac-dashboard.yaml
@@ -42,9 +42,7 @@ views:
               - low
               - medium
               - high
-          - type: climate-preset-modes
-            preset_modes:
-              - away
+
 
       # ----------------------------------------------------------------
       # Outdoor & indoor conditions — the physical thermostat shows
@@ -115,7 +113,7 @@ views:
 
       # ----------------------------------------------------------------
       # Vacation configuration — only visible when Allow Control is
-      # unlocked. Set these before selecting the Away preset above.
+      # unlocked. Set days and temps, then press Activate Vacation.
       # ----------------------------------------------------------------
       - type: conditional
         conditions:
@@ -135,6 +133,12 @@ views:
             - entity: number.abcdesp_vacation_max_temp
               name: Vacation Max Temp
               icon: mdi:thermometer-high
+            - entity: button.abcdesp_activate_vacation
+              name: Activate Vacation
+              icon: mdi:airplane-takeoff
+            - entity: button.abcdesp_cancel_vacation
+              name: Cancel Vacation
+              icon: mdi:airplane-off
 
       # ----------------------------------------------------------------
       # Safety & communication


### PR DESCRIPTION
## Changes

Remove the `CLIMATE_PRESET_AWAY` preset entirely and replace it with dedicated **Activate Vacation** and **Cancel Vacation** button entities.

### Why

The Away preset caused persistent UX issues — HA's thermostat card always showed a preset selector even when vacation wasn't active, and the preset state was difficult to keep in sync with the thermostat's actual vacation status. Dedicated buttons are clearer: set vacation parameters (days, min/max temp), press Activate, and press Cancel when done.

### What changed

- **`abcdesp.cpp`**: Remove preset handling from `control()` and `traits()`. Add `activate_vacation()` and `cancel_vacation()` methods with control-gate checks. Add `ActivateVacationButton` and `CancelVacationButton` press handlers.
- **`abcdesp.h`**: Add button classes, method declarations, and member pointers.
- **`__init__.py`**: Register new button classes, config keys, schema entries, and codegen.
- **`abcdesp.yaml`**: Add `activate_vacation_button` and `cancel_vacation_button` entities.
- **`hvac-dashboard.yaml`**: Add buttons to the Vacation Settings card, remove preset-modes from the thermostat card.