### PR TITLE
Fix hold active, cool setpoint, vacation preset, and blocked control UI

### DIFF
--- a/components/abcdesp/abcdesp.cpp
+++ b/components/abcdesp/abcdesp.cpp
@@ -680,8 +680,8 @@ void AbcdEspComponent::parse_tstat_zones(const uint8_t *data,
            fan_mode_, zone_hold_, heat_setpoint_, cool_setpoint_,
            zone_override_flag_, zone1_override_minutes_);
 
-  // Publish hold status
-  bool hold_active = (zone_hold_ & 0x01) != 0;
+  // Publish hold status — active if permanent hold OR timed override is set
+  bool hold_active = ((zone_hold_ & 0x01) != 0) || ((zone_override_flag_ & 0x01) != 0);
   if (hold_active_sensor_ != nullptr &&
       (!hold_active_initialized_ || hold_active != prev_hold_active_)) {
     hold_active_sensor_->publish_state(hold_active);
@@ -864,8 +864,12 @@ climate::ClimateTraits AbcdEspComponent::traits() {
       climate::CLIMATE_FAN_HIGH,
   });
 
-  // No presets declared — Away is set dynamically only when vacation is active.
-  // This prevents the thermostat card from always showing an "Away" button.
+  // Declare Away preset so HA recognises it when vacation is active.
+  // The preset is only set dynamically in publish_climate_state().
+  traits.set_supported_presets({
+      climate::CLIMATE_PRESET_HOME,
+      climate::CLIMATE_PRESET_AWAY,
+  });
 
   return traits;
 }
@@ -885,6 +889,8 @@ void AbcdEspComponent::control(const climate::ClimateCall &call) {
   // Block control when Allow Control lock is locked (or not configured)
   if (!is_control_allowed()) {
     ESP_LOGW(TAG, "Control blocked: Allow Control is locked");
+    // Re-publish current state so HA reverts any optimistic UI update
+    publish_climate_state();
     return;
   }
 
@@ -1085,19 +1091,28 @@ void AbcdEspComponent::publish_climate_state() {
   }
 
   // Target temperatures (convert °F → °C for HA)
-  // Use single target in heat/cool modes, dual target in auto mode
+  // Use single target in heat/cool modes, dual target in auto mode.
+  // Clear the unused target fields so HA doesn't show stale values.
   switch (this->mode) {
     case climate::CLIMATE_MODE_HEAT:
       this->target_temperature = f_to_c(static_cast<float>(heat_setpoint_));
+      this->target_temperature_low = NAN;
+      this->target_temperature_high = NAN;
       break;
     case climate::CLIMATE_MODE_COOL:
       this->target_temperature = f_to_c(static_cast<float>(cool_setpoint_));
+      this->target_temperature_low = NAN;
+      this->target_temperature_high = NAN;
       break;
     case climate::CLIMATE_MODE_HEAT_COOL:
       this->target_temperature_low = f_to_c(static_cast<float>(heat_setpoint_));
       this->target_temperature_high = f_to_c(static_cast<float>(cool_setpoint_));
+      this->target_temperature = NAN;
       break;
     default:
+      this->target_temperature = NAN;
+      this->target_temperature_low = NAN;
+      this->target_temperature_high = NAN;
       break;
   }
 
@@ -1146,7 +1161,7 @@ void AbcdEspComponent::publish_climate_state() {
   if (vacation_active_) {
     this->preset = climate::CLIMATE_PRESET_AWAY;
   } else {
-    this->preset.reset();
+    this->preset = climate::CLIMATE_PRESET_HOME;
   }
 
   this->publish_state();

--- a/tests/test_protocol.cpp
+++ b/tests/test_protocol.cpp
@@ -685,6 +685,51 @@ TEST(setpoint_f_to_c_rounding) {
   PASS();
 }
 
+TEST(target_temp_clear_stale_on_mode_switch) {
+  printf("test_target_temp_clear_stale_on_mode_switch\n");
+  // When switching from AUTO (dual target) to HEAT or COOL (single target),
+  // the unused target fields must be NaN so HA doesn't show stale values.
+
+  uint8_t heat_setpoint = 68;
+  uint8_t cool_setpoint = 76;
+  float target_temperature = NAN;
+  float target_temperature_low = NAN;
+  float target_temperature_high = NAN;
+
+  // Simulate AUTO mode — sets dual targets, clears single
+  target_temperature_low = f_to_c(static_cast<float>(heat_setpoint));
+  target_temperature_high = f_to_c(static_cast<float>(cool_setpoint));
+  target_temperature = NAN;
+  ASSERT_TRUE(!std::isnan(target_temperature_low));
+  ASSERT_TRUE(!std::isnan(target_temperature_high));
+  ASSERT_TRUE(std::isnan(target_temperature));
+
+  // Simulate switching to COOL mode — must clear dual targets
+  target_temperature = f_to_c(static_cast<float>(cool_setpoint));
+  target_temperature_low = NAN;
+  target_temperature_high = NAN;
+  ASSERT_TRUE(!std::isnan(target_temperature));
+  ASSERT_TRUE(std::isnan(target_temperature_low));   // must be NaN
+  ASSERT_TRUE(std::isnan(target_temperature_high));  // must be NaN
+
+  // Simulate switching to HEAT mode — must clear dual targets
+  target_temperature = f_to_c(static_cast<float>(heat_setpoint));
+  target_temperature_low = NAN;
+  target_temperature_high = NAN;
+  ASSERT_TRUE(!std::isnan(target_temperature));
+  ASSERT_TRUE(std::isnan(target_temperature_low));
+  ASSERT_TRUE(std::isnan(target_temperature_high));
+
+  // Simulate switching to OFF — all NaN
+  target_temperature = NAN;
+  target_temperature_low = NAN;
+  target_temperature_high = NAN;
+  ASSERT_TRUE(std::isnan(target_temperature));
+  ASSERT_TRUE(std::isnan(target_temperature_low));
+  ASSERT_TRUE(std::isnan(target_temperature_high));
+  PASS();
+}
+
 TEST(heatpump_3e01_unsigned_sanity) {
   printf("test_heatpump_3e01_unsigned_sanity\n");
   // 3E01 temps are parsed as uint16/16.0. Verify that values >0x7FFF
@@ -1029,6 +1074,44 @@ TEST(vacation_3b04_roundtrip) {
   // Verify deactivation payload
   memset(vac_buf, 0, sizeof(vac_buf));
   ASSERT_EQ(vac_buf[0], 0x00);  // inactive
+  PASS();
+}
+
+TEST(hold_active_includes_timed_override) {
+  printf("test_hold_active_includes_timed_override\n");
+  // hold_active should be true when EITHER zone_hold bit 0 OR
+  // zone_override_flag bit 0 is set (Bug: previously only checked zone_hold).
+
+  uint8_t zone_hold = 0;
+  uint8_t zone_override_flag = 0;
+
+  // Neither permanent hold nor timed override — not active
+  bool hold_active = ((zone_hold & 0x01) != 0) || ((zone_override_flag & 0x01) != 0);
+  ASSERT_TRUE(!hold_active);
+
+  // Permanent hold only (no timed override)
+  zone_hold = 0x01;
+  zone_override_flag = 0x00;
+  hold_active = ((zone_hold & 0x01) != 0) || ((zone_override_flag & 0x01) != 0);
+  ASSERT_TRUE(hold_active);
+
+  // Timed override only (no permanent hold flag) — this is the bug case
+  zone_hold = 0x00;
+  zone_override_flag = 0x01;
+  hold_active = ((zone_hold & 0x01) != 0) || ((zone_override_flag & 0x01) != 0);
+  ASSERT_TRUE(hold_active);
+
+  // Both permanent hold and timed override
+  zone_hold = 0x01;
+  zone_override_flag = 0x01;
+  hold_active = ((zone_hold & 0x01) != 0) || ((zone_override_flag & 0x01) != 0);
+  ASSERT_TRUE(hold_active);
+
+  // Zone 2 override only — zone 1 not active
+  zone_hold = 0x00;
+  zone_override_flag = 0x02;
+  hold_active = ((zone_hold & 0x01) != 0) || ((zone_override_flag & 0x01) != 0);
+  ASSERT_TRUE(!hold_active);
   PASS();
 }
 


### PR DESCRIPTION
## Summary

Fixes four bugs discovered during hardware testing (read-only mode tests A.2–A.7):

### Bugs Fixed

1. **Hold Active false negatives on timed holds** — `hold_active` only checked the permanent hold bitmap (`zone_hold_` byte 11). The thermostat uses the timed override flag (byte 37) for timed holds, so Hold Active showed OFF while Hold Time Remaining correctly counted down. Now checks both: `((zone_hold_ & 0x01) != 0) || ((zone_override_flag_ & 0x01) != 0)`.

2. **Cool mode setpoint not displayed** — When switching from AUTO (dual target) to COOL (single target), stale `target_temperature_low`/`target_temperature_high` values weren't cleared. HA continued showing the two-point UI. Now NaN-clears unused target fields on every mode.

3. **Vacation preset never shown** — `traits()` didn't declare `CLIMATE_PRESET_AWAY` in supported presets, so ESPHome ignored the dynamically-set preset. Added `HOME` and `AWAY` to `set_supported_presets()`.

4. **No UI feedback when control is blocked** — `control()` returned early without re-publishing state, so HA's optimistic UI update wasn't reverted. Now calls `publish_climate_state()` before returning.

### Tests Added

- `hold_active_includes_timed_override` — verifies hold_active is true for timed overrides
- `target_temp_clear_stale_on_mode_switch` — verifies stale target fields are NaN after mode changes