### PR TITLE
Remove Home/Away presets, add Vacation Active binary sensor

### DIFF
--- a/abcdesp.yaml
+++ b/abcdesp.yaml
@@ -103,6 +103,8 @@ abcdesp:
     name: "Activate Vacation"
   cancel_vacation_button:
     name: "Cancel Vacation"
+  vacation_active_sensor:
+    name: "Vacation Active"
   last_seen_sensor:
     name: "Last Seen"
 

--- a/components/abcdesp/__init__.py
+++ b/components/abcdesp/__init__.py
@@ -55,6 +55,7 @@ CONF_VACATION_MIN_TEMP_NUMBER = "vacation_min_temp_number"
 CONF_VACATION_MAX_TEMP_NUMBER = "vacation_max_temp_number"
 CONF_ACTIVATE_VACATION_BUTTON = "activate_vacation_button"
 CONF_CANCEL_VACATION_BUTTON = "cancel_vacation_button"
+CONF_VACATION_ACTIVE_SENSOR = "vacation_active_sensor"
 CONF_LAST_SEEN_SENSOR = "last_seen_sensor"
 
 CONFIG_SCHEMA = (
@@ -174,6 +175,9 @@ CONFIG_SCHEMA = (
                 CancelVacationButton,
                 icon="mdi:airplane-off",
                 entity_category=ENTITY_CATEGORY_CONFIG,
+            ),
+            cv.Optional(CONF_VACATION_ACTIVE_SENSOR): binary_sensor.binary_sensor_schema(
+                icon="mdi:airplane",
             ),
             cv.Optional(CONF_LAST_SEEN_SENSOR): sensor.sensor_schema(
                 unit_of_measurement="s",
@@ -313,6 +317,10 @@ async def to_code(config):
         btn = await button.new_button(config[CONF_CANCEL_VACATION_BUTTON])
         cg.add(btn.set_parent(var))
         cg.add(var.set_cancel_vacation_button(btn))
+
+    if CONF_VACATION_ACTIVE_SENSOR in config:
+        sens = await binary_sensor.new_binary_sensor(config[CONF_VACATION_ACTIVE_SENSOR])
+        cg.add(var.set_vacation_active_sensor(sens))
 
     cg.add(var.set_hold_duration_minutes(config[CONF_HOLD_DURATION_MINUTES]))
 

--- a/components/abcdesp/abcdesp.cpp
+++ b/components/abcdesp/abcdesp.cpp
@@ -834,6 +834,9 @@ void AbcdEspComponent::parse_vacation(const uint8_t *data, uint8_t len) {
 
   if (!vacation_initialized_ || vacation_active_ != was_active) {
     vacation_initialized_ = true;
+    if (vacation_active_sensor_ != nullptr) {
+      vacation_active_sensor_->publish_state(vacation_active_);
+    }
     publish_climate_state();
   }
 }
@@ -862,13 +865,6 @@ climate::ClimateTraits AbcdEspComponent::traits() {
       climate::CLIMATE_FAN_LOW,
       climate::CLIMATE_FAN_MEDIUM,
       climate::CLIMATE_FAN_HIGH,
-  });
-
-  // Declare Away preset so HA recognises it when vacation is active.
-  // The preset is only set dynamically in publish_climate_state().
-  traits.set_supported_presets({
-      climate::CLIMATE_PRESET_HOME,
-      climate::CLIMATE_PRESET_AWAY,
   });
 
   return traits;
@@ -1155,13 +1151,6 @@ void AbcdEspComponent::publish_climate_state() {
     this->action = climate::CLIMATE_ACTION_FAN;
   } else {
     this->action = climate::CLIMATE_ACTION_IDLE;
-  }
-
-  // Preset — only show Away when vacation is active
-  if (vacation_active_) {
-    this->preset = climate::CLIMATE_PRESET_AWAY;
-  } else {
-    this->preset = climate::CLIMATE_PRESET_HOME;
   }
 
   this->publish_state();

--- a/components/abcdesp/abcdesp.cpp
+++ b/components/abcdesp/abcdesp.cpp
@@ -680,8 +680,8 @@ void AbcdEspComponent::parse_tstat_zones(const uint8_t *data,
            fan_mode_, zone_hold_, heat_setpoint_, cool_setpoint_,
            zone_override_flag_, zone1_override_minutes_);
 
-  // Publish hold status
-  bool hold_active = (zone_hold_ & 0x01) != 0;
+  // Publish hold status — active if permanent hold OR timed override is set
+  bool hold_active = ((zone_hold_ & 0x01) != 0) || ((zone_override_flag_ & 0x01) != 0);
   if (hold_active_sensor_ != nullptr &&
       (!hold_active_initialized_ || hold_active != prev_hold_active_)) {
     hold_active_sensor_->publish_state(hold_active);
@@ -864,8 +864,12 @@ climate::ClimateTraits AbcdEspComponent::traits() {
       climate::CLIMATE_FAN_HIGH,
   });
 
-  // No presets declared — Away is set dynamically only when vacation is active.
-  // This prevents the thermostat card from always showing an "Away" button.
+  // Declare Away preset so HA recognises it when vacation is active.
+  // The preset is only set dynamically in publish_climate_state().
+  traits.set_supported_presets({
+      climate::CLIMATE_PRESET_HOME,
+      climate::CLIMATE_PRESET_AWAY,
+  });
 
   return traits;
 }
@@ -885,6 +889,8 @@ void AbcdEspComponent::control(const climate::ClimateCall &call) {
   // Block control when Allow Control lock is locked (or not configured)
   if (!is_control_allowed()) {
     ESP_LOGW(TAG, "Control blocked: Allow Control is locked");
+    // Re-publish current state so HA reverts any optimistic UI update
+    publish_climate_state();
     return;
   }
 
@@ -1085,19 +1091,28 @@ void AbcdEspComponent::publish_climate_state() {
   }
 
   // Target temperatures (convert °F → °C for HA)
-  // Use single target in heat/cool modes, dual target in auto mode
+  // Use single target in heat/cool modes, dual target in auto mode.
+  // Clear the unused target fields so HA doesn't show stale values.
   switch (this->mode) {
     case climate::CLIMATE_MODE_HEAT:
       this->target_temperature = f_to_c(static_cast<float>(heat_setpoint_));
+      this->target_temperature_low = NAN;
+      this->target_temperature_high = NAN;
       break;
     case climate::CLIMATE_MODE_COOL:
       this->target_temperature = f_to_c(static_cast<float>(cool_setpoint_));
+      this->target_temperature_low = NAN;
+      this->target_temperature_high = NAN;
       break;
     case climate::CLIMATE_MODE_HEAT_COOL:
       this->target_temperature_low = f_to_c(static_cast<float>(heat_setpoint_));
       this->target_temperature_high = f_to_c(static_cast<float>(cool_setpoint_));
+      this->target_temperature = NAN;
       break;
     default:
+      this->target_temperature = NAN;
+      this->target_temperature_low = NAN;
+      this->target_temperature_high = NAN;
       break;
   }
 
@@ -1146,7 +1161,7 @@ void AbcdEspComponent::publish_climate_state() {
   if (vacation_active_) {
     this->preset = climate::CLIMATE_PRESET_AWAY;
   } else {
-    this->preset.reset();
+    this->preset = climate::CLIMATE_PRESET_HOME;
   }
 
   this->publish_state();

--- a/components/abcdesp/abcdesp.h
+++ b/components/abcdesp/abcdesp.h
@@ -230,6 +230,7 @@ class AbcdEspComponent : public Component,
   void set_vacation_max_temp_number(VacationMaxTempNumber *n) { vacation_max_temp_number_ = n; }
   void set_activate_vacation_button(ActivateVacationButton *b) { activate_vacation_button_ = b; }
   void set_cancel_vacation_button(CancelVacationButton *b) { cancel_vacation_button_ = b; }
+  void set_vacation_active_sensor(binary_sensor::BinarySensor *s) { vacation_active_sensor_ = s; }
   void set_last_seen_sensor(sensor::Sensor *s) { last_seen_sensor_ = s; }
 
   // Returns true when the Allow Control lock is unlocked
@@ -391,6 +392,9 @@ class AbcdEspComponent : public Component,
   // Vacation buttons
   ActivateVacationButton *activate_vacation_button_{nullptr};
   CancelVacationButton *cancel_vacation_button_{nullptr};
+
+  // Vacation active sensor
+  binary_sensor::BinarySensor *vacation_active_sensor_{nullptr};
 
   // Runtime hold duration number entities
   HoldDurationNumber *hold_duration_number_{nullptr};

--- a/tests/test_protocol.cpp
+++ b/tests/test_protocol.cpp
@@ -685,6 +685,51 @@ TEST(setpoint_f_to_c_rounding) {
   PASS();
 }
 
+TEST(target_temp_clear_stale_on_mode_switch) {
+  printf("test_target_temp_clear_stale_on_mode_switch\n");
+  // When switching from AUTO (dual target) to HEAT or COOL (single target),
+  // the unused target fields must be NaN so HA doesn't show stale values.
+
+  uint8_t heat_setpoint = 68;
+  uint8_t cool_setpoint = 76;
+  float target_temperature = NAN;
+  float target_temperature_low = NAN;
+  float target_temperature_high = NAN;
+
+  // Simulate AUTO mode — sets dual targets, clears single
+  target_temperature_low = f_to_c(static_cast<float>(heat_setpoint));
+  target_temperature_high = f_to_c(static_cast<float>(cool_setpoint));
+  target_temperature = NAN;
+  ASSERT_TRUE(!std::isnan(target_temperature_low));
+  ASSERT_TRUE(!std::isnan(target_temperature_high));
+  ASSERT_TRUE(std::isnan(target_temperature));
+
+  // Simulate switching to COOL mode — must clear dual targets
+  target_temperature = f_to_c(static_cast<float>(cool_setpoint));
+  target_temperature_low = NAN;
+  target_temperature_high = NAN;
+  ASSERT_TRUE(!std::isnan(target_temperature));
+  ASSERT_TRUE(std::isnan(target_temperature_low));   // must be NaN
+  ASSERT_TRUE(std::isnan(target_temperature_high));  // must be NaN
+
+  // Simulate switching to HEAT mode — must clear dual targets
+  target_temperature = f_to_c(static_cast<float>(heat_setpoint));
+  target_temperature_low = NAN;
+  target_temperature_high = NAN;
+  ASSERT_TRUE(!std::isnan(target_temperature));
+  ASSERT_TRUE(std::isnan(target_temperature_low));
+  ASSERT_TRUE(std::isnan(target_temperature_high));
+
+  // Simulate switching to OFF — all NaN
+  target_temperature = NAN;
+  target_temperature_low = NAN;
+  target_temperature_high = NAN;
+  ASSERT_TRUE(std::isnan(target_temperature));
+  ASSERT_TRUE(std::isnan(target_temperature_low));
+  ASSERT_TRUE(std::isnan(target_temperature_high));
+  PASS();
+}
+
 TEST(heatpump_3e01_unsigned_sanity) {
   printf("test_heatpump_3e01_unsigned_sanity\n");
   // 3E01 temps are parsed as uint16/16.0. Verify that values >0x7FFF
@@ -1029,6 +1074,44 @@ TEST(vacation_3b04_roundtrip) {
   // Verify deactivation payload
   memset(vac_buf, 0, sizeof(vac_buf));
   ASSERT_EQ(vac_buf[0], 0x00);  // inactive
+  PASS();
+}
+
+TEST(hold_active_includes_timed_override) {
+  printf("test_hold_active_includes_timed_override\n");
+  // hold_active should be true when EITHER zone_hold bit 0 OR
+  // zone_override_flag bit 0 is set (Bug: previously only checked zone_hold).
+
+  uint8_t zone_hold = 0;
+  uint8_t zone_override_flag = 0;
+
+  // Neither permanent hold nor timed override — not active
+  bool hold_active = ((zone_hold & 0x01) != 0) || ((zone_override_flag & 0x01) != 0);
+  ASSERT_TRUE(!hold_active);
+
+  // Permanent hold only (no timed override)
+  zone_hold = 0x01;
+  zone_override_flag = 0x00;
+  hold_active = ((zone_hold & 0x01) != 0) || ((zone_override_flag & 0x01) != 0);
+  ASSERT_TRUE(hold_active);
+
+  // Timed override only (no permanent hold flag) — this is the bug case
+  zone_hold = 0x00;
+  zone_override_flag = 0x01;
+  hold_active = ((zone_hold & 0x01) != 0) || ((zone_override_flag & 0x01) != 0);
+  ASSERT_TRUE(hold_active);
+
+  // Both permanent hold and timed override
+  zone_hold = 0x01;
+  zone_override_flag = 0x01;
+  hold_active = ((zone_hold & 0x01) != 0) || ((zone_override_flag & 0x01) != 0);
+  ASSERT_TRUE(hold_active);
+
+  // Zone 2 override only — zone 1 not active
+  zone_hold = 0x00;
+  zone_override_flag = 0x02;
+  hold_active = ((zone_hold & 0x01) != 0) || ((zone_override_flag & 0x01) != 0);
+  ASSERT_TRUE(!hold_active);
   PASS();
 }
 


### PR DESCRIPTION
## Summary

The preset picker (Home/Away) added in #30 always shows in the HA climate card, which is unwanted — the thermostat doesn't have a native home/away concept. Vacation is already managed via dedicated Activate/Cancel Vacation buttons.

### Changes

- **Remove presets from `traits()`** — no `set_supported_presets()` call, so the preset picker disappears from the climate card
- **Remove preset publishing from `publish_climate_state()`** — no more `CLIMATE_PRESET_AWAY`/`HOME` assignment
- **Add `vacation_active_sensor`** — new optional `binary_sensor` that publishes `true`/`false` when vacation state changes on the 3B04 register, giving clear visibility without cluttering the climate card

### YAML config addition

```yaml
abcdesp:
  vacation_active_sensor:
    name: "Vacation Active"
```