### PR TITLE
Fix vacation_active false positive when days=0

### DIFF
--- a/components/abcdesp/abcdesp.cpp
+++ b/components/abcdesp/abcdesp.cpp
@@ -813,8 +813,15 @@ void AbcdEspComponent::parse_vacation(const uint8_t *data, uint8_t len) {
     uint8_t vac_min_temp = data[3];
     uint8_t vac_max_temp = data[4];
 
-    ESP_LOGD(TAG, "3B04: vacation=%s  days=%d  min=%d°F  max=%d°F",
-             vacation_active_ ? "active" : "off", vac_days, vac_min_temp, vac_max_temp);
+    // A vacation with 0 days remaining is not really active — the thermostat
+    // may keep byte 0 non-zero after a vacation expires or is configured.
+    if (vacation_active_ && days_x7 == 0) {
+      vacation_active_ = false;
+    }
+
+    ESP_LOGD(TAG, "3B04: byte0=0x%02X  vacation=%s  days=%d  min=%d°F  max=%d°F",
+             data[0], vacation_active_ ? "active" : "off", vac_days,
+             vac_min_temp, vac_max_temp);
 
     // Update number entities with current thermostat values when vacation is active
     if (vacation_active_) {

--- a/tests/test_protocol.cpp
+++ b/tests/test_protocol.cpp
@@ -540,6 +540,29 @@ TEST(parse_vacation_3b04) {
   // Inactive vacation
   data[0] = 0x00;
   ASSERT_EQ(data[0], 0);
+
+  // Byte 0 non-zero but days=0 — should NOT be considered active
+  // (thermostat may keep byte 0 set after vacation expires)
+  data[0] = 0x01;
+  data[1] = 0x00;
+  data[2] = 0x00;  // days*7 = 0
+  days_times7 = (data[1] << 8) | data[2];
+  bool vacation_active = (data[0] != 0);
+  if (vacation_active && days_times7 == 0) {
+    vacation_active = false;
+  }
+  ASSERT_TRUE(!vacation_active);
+
+  // Byte 0 non-zero AND days > 0 — genuinely active
+  data[0] = 0x01;
+  data[1] = 0x00;
+  data[2] = 0x07;  // days*7 = 7 (1 day)
+  days_times7 = (data[1] << 8) | data[2];
+  vacation_active = (data[0] != 0);
+  if (vacation_active && days_times7 == 0) {
+    vacation_active = false;
+  }
+  ASSERT_TRUE(vacation_active);
   PASS();
 }
 


### PR DESCRIPTION
## Problem

The Vacation Active binary sensor reports ON immediately after boot even though no vacation is active. The thermostat keeps 3B04 byte 0 non-zero after a vacation expires or is merely configured, resulting in `data[0] != 0` being true with `days=0, min=0°F, max=0°F`.

Debug log:
```
3B04: vacation=active  days=0  min=0°F  max=0°F
binary_sensor: 'Vacation Active' >> ON
```

## Fix

Require `days_x7 > 0` in addition to `data[0] != 0` to consider vacation genuinely active. A vacation with 0 days remaining is not a real vacation.

Also adds the raw byte 0 hex value to the debug log for future protocol investigation.

## Test added

Extended `parse_vacation_3b04` test to verify that byte 0 non-zero + days=0 → inactive, and byte 0 non-zero + days>0 → active.