### PR TITLE
Fix mode 3 (EHEAT) mapping and action update timing

### DIFF
--- a/components/abcdesp/abcdesp.cpp
+++ b/components/abcdesp/abcdesp.cpp
@@ -720,6 +720,7 @@ void AbcdEspComponent::parse_airhandler_06(const uint8_t *data,
 
   if (blower_running_ != was_running) {
     publish_sensors();
+    publish_climate_state();  // action depends on blower state
   }
 }
 
@@ -742,6 +743,7 @@ void AbcdEspComponent::parse_airhandler_16(const uint8_t *data,
   ESP_LOGD(TAG, "0316: heat_stage=%d  CFM=%d", heat_stage_, airflow_cfm_);
 
   publish_sensors();
+  publish_climate_state();  // action depends on heat_stage and blower
 }
 
 // ==========================================================================
@@ -791,6 +793,7 @@ void AbcdEspComponent::parse_heatpump_02(const uint8_t *data,
   hp_stage_ = data[0] >> 1;
   ESP_LOGD(TAG, "3E02: HP stage=%d", hp_stage_);
   publish_sensors();
+  publish_climate_state();  // action depends on hp_stage
 }
 
 // ==========================================================================
@@ -802,6 +805,15 @@ void AbcdEspComponent::parse_vacation(const uint8_t *data, uint8_t len) {
   if (len < 1) {
     return;
   }
+
+  // Hex dump all bytes for protocol debugging
+  char hex_buf[3 * 16 + 1];
+  uint8_t dump_len = (len > 16) ? 16 : len;
+  for (uint8_t i = 0; i < dump_len; i++) {
+    snprintf(hex_buf + i * 3, 4, "%02X ", data[i]);
+  }
+  hex_buf[dump_len * 3] = '\0';
+  ESP_LOGD(TAG, "3B04 raw (%d bytes): %s", len, hex_buf);
 
   bool was_active = vacation_active_;
   vacation_active_ = (data[0] != 0);
@@ -962,7 +974,7 @@ void AbcdEspComponent::control(const climate::ClimateCall &call) {
     uint8_t target = static_cast<uint8_t>(c_to_f(*call.get_target_temperature()) + 0.5f);
     // Determine which setpoint based on effective mode
     uint8_t effective_mode = call.get_mode().has_value() ? new_mode : current_mode_;
-    if (effective_mode == MODE_HEAT) {
+    if (effective_mode == MODE_HEAT || effective_mode == MODE_EHEAT) {
       new_heat = target;
       flags |= 0x0004;  // heat setpoint flag
     } else if (effective_mode == MODE_COOL) {
@@ -1079,6 +1091,7 @@ void AbcdEspComponent::publish_climate_state() {
   // Mode
   switch (current_mode_) {
     case MODE_HEAT:
+    case MODE_EHEAT:
       this->mode = climate::CLIMATE_MODE_HEAT;
       break;
     case MODE_COOL:
@@ -1152,7 +1165,7 @@ void AbcdEspComponent::publish_climate_state() {
     } else {
       this->action = climate::CLIMATE_ACTION_COOLING;
     }
-  } else if (hp_stage_ > 0 && current_mode_ == MODE_HEAT) {
+  } else if (hp_stage_ > 0 && (current_mode_ == MODE_HEAT || current_mode_ == MODE_EHEAT)) {
     this->action = climate::CLIMATE_ACTION_HEATING;
   } else if (blower_running_) {
     this->action = climate::CLIMATE_ACTION_FAN;

--- a/components/abcdesp/abcdesp.h
+++ b/components/abcdesp/abcdesp.h
@@ -55,6 +55,7 @@ static const uint8_t ROW_HP_02         = 0x02;   // 3E02 — stage
 static const uint8_t MODE_HEAT          = 0x00;
 static const uint8_t MODE_COOL          = 0x01;
 static const uint8_t MODE_AUTO          = 0x02;
+static const uint8_t MODE_EHEAT         = 0x03;  // electric/HP heat
 static const uint8_t MODE_OFF           = 0x05;
 
 // Fan mode values

--- a/tests/test_protocol.cpp
+++ b/tests/test_protocol.cpp
@@ -35,7 +35,8 @@ static const uint8_t REG_PREFIX       = 0x00;
 static const uint8_t MODE_HEAT = 0x00;
 static const uint8_t MODE_COOL = 0x01;
 static const uint8_t MODE_AUTO = 0x02;
-static const uint8_t MODE_EHEAT = 0x03;\nstatic const uint8_t MODE_OFF  = 0x05;
+static const uint8_t MODE_EHEAT = 0x03;
+static const uint8_t MODE_OFF  = 0x05;
 
 static const uint8_t FAN_AUTO = 0x00;
 static const uint8_t FAN_LOW  = 0x01;

--- a/tests/test_protocol.cpp
+++ b/tests/test_protocol.cpp
@@ -35,7 +35,7 @@ static const uint8_t REG_PREFIX       = 0x00;
 static const uint8_t MODE_HEAT = 0x00;
 static const uint8_t MODE_COOL = 0x01;
 static const uint8_t MODE_AUTO = 0x02;
-static const uint8_t MODE_OFF  = 0x05;
+static const uint8_t MODE_EHEAT = 0x03;\nstatic const uint8_t MODE_OFF  = 0x05;
 
 static const uint8_t FAN_AUTO = 0x00;
 static const uint8_t FAN_LOW  = 0x01;
@@ -501,7 +501,30 @@ TEST(mode_encoding) {
   ASSERT_EQ(MODE_HEAT, 0x00);
   ASSERT_EQ(MODE_COOL, 0x01);
   ASSERT_EQ(MODE_AUTO, 0x02);
+  ASSERT_EQ(MODE_EHEAT, 0x03);
   ASSERT_EQ(MODE_OFF,  0x05);
+
+  // Both MODE_HEAT and MODE_EHEAT should map to heating
+  auto mode_to_climate = [](uint8_t m) -> int {
+    switch (m) {
+      case MODE_HEAT:
+      case MODE_EHEAT:
+        return 1;  // CLIMATE_MODE_HEAT
+      case MODE_COOL:
+        return 2;  // CLIMATE_MODE_COOL
+      case MODE_AUTO:
+        return 3;  // CLIMATE_MODE_HEAT_COOL
+      case MODE_OFF:
+      default:
+        return 0;  // CLIMATE_MODE_OFF
+    }
+  };
+  ASSERT_EQ(mode_to_climate(MODE_HEAT), 1);
+  ASSERT_EQ(mode_to_climate(MODE_EHEAT), 1);
+  ASSERT_EQ(mode_to_climate(MODE_COOL), 2);
+  ASSERT_EQ(mode_to_climate(MODE_AUTO), 3);
+  ASSERT_EQ(mode_to_climate(MODE_OFF), 0);
+  ASSERT_EQ(mode_to_climate(0x07), 0);  // unknown mode → OFF
   PASS();
 }
 
@@ -1606,6 +1629,63 @@ TEST(vacation_deactivation_payload) {
   InfinityFrame parsed;
   ASSERT_TRUE(parse_frame(buf, buf_len, parsed));
   ASSERT_EQ(parsed.data[3], 0x00);  // inactive
+  PASS();
+}
+
+TEST(action_depends_on_stage_and_mode) {
+  printf("test_action_depends_on_stage_and_mode\n");
+
+  // Replicate the action logic from publish_climate_state
+  auto compute_action = [](uint8_t mode, uint8_t heat_stage, uint8_t hp_stage,
+                           bool blower_running) -> int {
+    // Return values mirror ClimateAction enum
+    const int ACTION_OFF = 0;
+    const int ACTION_HEATING = 2;
+    const int ACTION_COOLING = 1;
+    const int ACTION_FAN = 4;
+    const int ACTION_IDLE = 3;
+
+    if (mode == MODE_OFF) {
+      return ACTION_OFF;
+    } else if (heat_stage > 0) {
+      return ACTION_HEATING;
+    } else if (hp_stage > 0 && mode == MODE_COOL) {
+      return ACTION_COOLING;
+    } else if (hp_stage > 0 && (mode == MODE_HEAT || mode == MODE_EHEAT)) {
+      return ACTION_HEATING;
+    } else if (blower_running) {
+      return ACTION_FAN;
+    } else {
+      return ACTION_IDLE;
+    }
+  };
+
+  // MODE_EHEAT (0x03) with heat_stage active → HEATING
+  ASSERT_EQ(compute_action(MODE_EHEAT, 2, 0, true), 2);
+
+  // MODE_EHEAT with hp_stage active → HEATING
+  ASSERT_EQ(compute_action(MODE_EHEAT, 0, 1, true), 2);
+
+  // MODE_HEAT with heat_stage active → HEATING
+  ASSERT_EQ(compute_action(MODE_HEAT, 1, 0, true), 2);
+
+  // MODE_HEAT with hp_stage active → HEATING
+  ASSERT_EQ(compute_action(MODE_HEAT, 0, 1, true), 2);
+
+  // MODE_COOL with hp_stage active → COOLING
+  ASSERT_EQ(compute_action(MODE_COOL, 0, 1, true), 1);
+
+  // MODE_OFF always → OFF regardless of stages
+  ASSERT_EQ(compute_action(MODE_OFF, 2, 1, true), 0);
+
+  // No stages, blower running → FAN
+  ASSERT_EQ(compute_action(MODE_HEAT, 0, 0, true), 4);
+  ASSERT_EQ(compute_action(MODE_EHEAT, 0, 0, true), 4);
+
+  // No stages, blower off → IDLE
+  ASSERT_EQ(compute_action(MODE_HEAT, 0, 0, false), 3);
+  ASSERT_EQ(compute_action(MODE_EHEAT, 0, 0, false), 3);
+
   PASS();
 }
 


### PR DESCRIPTION
## Summary

Fixes three bugs discovered during hardware testing:

### Bug 1 — Mode 3 unrecognized (shows "Off" when heating)
The thermostat reports `mode=3` for normal heat (both gas furnace and heat pump heating). The code only recognized modes 0, 1, 2, 5, so mode 3 fell through to the `default` case → `CLIMATE_MODE_OFF`.

- Added `MODE_EHEAT = 0x03` constant
- Both `MODE_HEAT` (0x00) and `MODE_EHEAT` (0x03) now map to `CLIMATE_MODE_HEAT`
- Action logic and setpoint write path also handle `MODE_EHEAT`

### Bug 2 — Action never updates on stage changes
`parse_airhandler_16()` and `parse_heatpump_02()` updated `heat_stage_` and `hp_stage_` but only called `publish_sensors()`, not `publish_climate_state()`. Since the climate action depends on these values, the action was never re-evaluated when heating/cooling actually started or stopped.

- Added `publish_climate_state()` calls to `parse_airhandler_16()`, `parse_heatpump_02()`, and the blower state change path in `parse_airhandler_06()`

### Diagnostic — Vacation hex dump
Added raw hex dump of all 3B04 bytes to help debug vacation detection on next hardware test. The thermostat's 3B04 read response did not change when vacation was activated, so more protocol investigation is needed.

### Tests
- Expanded `mode_encoding` test to verify `MODE_EHEAT` and mode→climate mapping
- Added `action_depends_on_stage_and_mode` test covering all action computation paths