### PR TITLE
Fix 3B04 vacation byte layout and target temp display

### DIFF
--- a/components/abcdesp/abcdesp.cpp
+++ b/components/abcdesp/abcdesp.cpp
@@ -867,7 +867,6 @@ void AbcdEspComponent::parse_vacation(const uint8_t *data, uint8_t len) {
 climate::ClimateTraits AbcdEspComponent::traits() {
   auto traits = climate::ClimateTraits();
   traits.add_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE |
-                           climate::CLIMATE_SUPPORTS_TARGET_TEMPERATURE |
                            climate::CLIMATE_SUPPORTS_TWO_POINT_TARGET_TEMPERATURE);
   traits.set_visual_min_temperature(f_to_c(40));   // 40°F ≈ 4.4°C
   traits.set_visual_max_temperature(f_to_c(99));   // 99°F ≈ 37.2°C
@@ -1109,30 +1108,19 @@ void AbcdEspComponent::publish_climate_state() {
   }
 
   // Target temperatures (convert °F → °C for HA)
-  // With both TARGET_TEMPERATURE and TWO_POINT_TARGET_TEMPERATURE declared,
-  // ESPHome uses single target in HEAT/COOL and dual in HEAT_COOL.
-  switch (this->mode) {
-    case climate::CLIMATE_MODE_HEAT:
-      this->target_temperature = f_to_c(static_cast<float>(heat_setpoint_));
-      this->target_temperature_low = NAN;
-      this->target_temperature_high = NAN;
-      break;
-    case climate::CLIMATE_MODE_COOL:
-      this->target_temperature = f_to_c(static_cast<float>(cool_setpoint_));
-      this->target_temperature_low = NAN;
-      this->target_temperature_high = NAN;
-      break;
-    case climate::CLIMATE_MODE_HEAT_COOL:
-      this->target_temperature_low = f_to_c(static_cast<float>(heat_setpoint_));
-      this->target_temperature_high = f_to_c(static_cast<float>(cool_setpoint_));
-      this->target_temperature = NAN;
-      break;
-    default:
-      this->target_temperature = NAN;
-      this->target_temperature_low = NAN;
-      this->target_temperature_high = NAN;
-      break;
+  // Traits declares TWO_POINT_TARGET_TEMPERATURE. ESPHome/HA thermostat card
+  // automatically shows just the relevant slider based on mode:
+  //   HEAT → shows only the low setpoint
+  //   COOL → shows only the high setpoint
+  //   HEAT_COOL → shows both as a range
+  if (this->mode == climate::CLIMATE_MODE_OFF) {
+    this->target_temperature_low = NAN;
+    this->target_temperature_high = NAN;
+  } else {
+    this->target_temperature_low = f_to_c(static_cast<float>(heat_setpoint_));
+    this->target_temperature_high = f_to_c(static_cast<float>(cool_setpoint_));
   }
+  this->target_temperature = NAN;
 
   // Fan mode
   switch (fan_mode_) {

--- a/components/abcdesp/abcdesp.cpp
+++ b/components/abcdesp/abcdesp.cpp
@@ -798,11 +798,19 @@ void AbcdEspComponent::parse_heatpump_02(const uint8_t *data,
 
 // ==========================================================================
 // Parse 3B04 — vacation settings (11 bytes)
-// Layout: [0]=vacation_active, [1-2]=days*7(BE), [3]=mintemp, [4]=maxtemp,
-//         [5]=minhumidity, [6]=maxhumidity, [7]=fanmode
+// Layout (confirmed via hardware logs):
+//   [0]    = zone count/status (always 0x01, NOT vacation flag)
+//   [1-2]  = unknown (always 0x00)
+//   [3]    = vacation_active (0=off, 1=on)
+//   [4-5]  = hours remaining (uint16 BE; e.g. 0x0030 = 48h = 2 days)
+//   [6]    = min temp (°F)
+//   [7]    = max temp (°F)
+//   [8]    = min humidity (%)
+//   [9]    = max humidity (%)
+//   [10]   = fan mode
 // ==========================================================================
 void AbcdEspComponent::parse_vacation(const uint8_t *data, uint8_t len) {
-  if (len < 1) {
+  if (len < 4) {
     return;
   }
 
@@ -816,23 +824,17 @@ void AbcdEspComponent::parse_vacation(const uint8_t *data, uint8_t len) {
   ESP_LOGD(TAG, "3B04 raw (%d bytes): %s", len, hex_buf);
 
   bool was_active = vacation_active_;
-  vacation_active_ = (data[0] != 0);
+  vacation_active_ = (data[3] != 0);
 
-  // Parse vacation parameters if present (bytes 1-7)
+  // Parse vacation parameters if present (bytes 4-10)
   if (len >= 8) {
-    uint16_t days_x7 = (data[1] << 8) | data[2];
-    uint8_t vac_days = (days_x7 > 0) ? (days_x7 / 7) : 0;
-    uint8_t vac_min_temp = data[3];
-    uint8_t vac_max_temp = data[4];
+    uint16_t hours = (data[4] << 8) | data[5];
+    uint8_t vac_days = (hours > 0) ? (hours / 24) : 0;
+    uint8_t vac_min_temp = data[6];
+    uint8_t vac_max_temp = data[7];
 
-    // A vacation with 0 days remaining is not really active — the thermostat
-    // may keep byte 0 non-zero after a vacation expires or is configured.
-    if (vacation_active_ && days_x7 == 0) {
-      vacation_active_ = false;
-    }
-
-    ESP_LOGD(TAG, "3B04: byte0=0x%02X  vacation=%s  days=%d  min=%d°F  max=%d°F",
-             data[0], vacation_active_ ? "active" : "off", vac_days,
+    ESP_LOGD(TAG, "3B04: vacation=%s  hours=%d  days=%d  min=%d°F  max=%d°F",
+             vacation_active_ ? "active" : "off", hours, vac_days,
              vac_min_temp, vac_max_temp);
 
     // Update number entities with current thermostat values when vacation is active
@@ -1107,30 +1109,17 @@ void AbcdEspComponent::publish_climate_state() {
   }
 
   // Target temperatures (convert °F → °C for HA)
-  // Use single target in heat/cool modes, dual target in auto mode.
-  // Clear the unused target fields so HA doesn't show stale values.
-  switch (this->mode) {
-    case climate::CLIMATE_MODE_HEAT:
-      this->target_temperature = f_to_c(static_cast<float>(heat_setpoint_));
-      this->target_temperature_low = NAN;
-      this->target_temperature_high = NAN;
-      break;
-    case climate::CLIMATE_MODE_COOL:
-      this->target_temperature = f_to_c(static_cast<float>(cool_setpoint_));
-      this->target_temperature_low = NAN;
-      this->target_temperature_high = NAN;
-      break;
-    case climate::CLIMATE_MODE_HEAT_COOL:
-      this->target_temperature_low = f_to_c(static_cast<float>(heat_setpoint_));
-      this->target_temperature_high = f_to_c(static_cast<float>(cool_setpoint_));
-      this->target_temperature = NAN;
-      break;
-    default:
-      this->target_temperature = NAN;
-      this->target_temperature_low = NAN;
-      this->target_temperature_high = NAN;
-      break;
+  // Always use dual target (low/high) because traits declares
+  // TWO_POINT_TARGET_TEMPERATURE — ESPHome ignores single target when
+  // that flag is set.  The thermostat always maintains both setpoints.
+  if (this->mode == climate::CLIMATE_MODE_OFF) {
+    this->target_temperature_low = NAN;
+    this->target_temperature_high = NAN;
+  } else {
+    this->target_temperature_low = f_to_c(static_cast<float>(heat_setpoint_));
+    this->target_temperature_high = f_to_c(static_cast<float>(cool_setpoint_));
   }
+  this->target_temperature = NAN;
 
   // Fan mode
   switch (fan_mode_) {
@@ -1394,20 +1383,22 @@ void AbcdEspComponent::activate_vacation() {
     vac_max_temp = static_cast<uint8_t>(vacation_max_temp_number_->state);
   }
 
-  uint16_t days_x7 = static_cast<uint16_t>(vac_days) * 7;
-  uint8_t vac_buf[8];
-  vac_buf[0] = 0x01;                       // vacation_active = 1
-  vac_buf[1] = (days_x7 >> 8) & 0xFF;      // days*7 high byte
-  vac_buf[2] = days_x7 & 0xFF;             // days*7 low byte
-  vac_buf[3] = vac_min_temp;               // min temp °F
-  vac_buf[4] = vac_max_temp;               // max temp °F
-  vac_buf[5] = 15;                         // min humidity
-  vac_buf[6] = 60;                         // max humidity
-  vac_buf[7] = FAN_AUTO;
+  uint16_t hours = static_cast<uint16_t>(vac_days) * 24;
+  uint8_t vac_buf[11];
+  memset(vac_buf, 0, sizeof(vac_buf));
+  vac_buf[0] = 0x01;                       // zone count/status
+  vac_buf[3] = 0x01;                       // vacation_active = 1
+  vac_buf[4] = (hours >> 8) & 0xFF;        // hours high byte
+  vac_buf[5] = hours & 0xFF;               // hours low byte
+  vac_buf[6] = vac_min_temp;               // min temp °F
+  vac_buf[7] = vac_max_temp;               // max temp °F
+  vac_buf[8] = 15;                         // min humidity
+  vac_buf[9] = 60;                         // max humidity
+  vac_buf[10] = FAN_AUTO;
   send_write_request(ADDR_TSTAT, TBL_SAM_INFO, ROW_SAM_VACATION,
-                     vac_buf, 8);
-  ESP_LOGI(TAG, "Activating vacation mode (%d days, %d-%dF)",
-           vac_days, vac_min_temp, vac_max_temp);
+                     vac_buf, 11);
+  ESP_LOGI(TAG, "Activating vacation mode (%d days / %d hours, %d-%dF)",
+           vac_days, hours, vac_min_temp, vac_max_temp);
 }
 
 // ==========================================================================
@@ -1424,11 +1415,12 @@ void AbcdEspComponent::cancel_vacation() {
     return;
   }
 
-  uint8_t vac_buf[8];
+  uint8_t vac_buf[11];
   memset(vac_buf, 0, sizeof(vac_buf));
-  vac_buf[0] = 0x00;  // vacation_active = 0
+  vac_buf[0] = 0x01;  // zone count/status (always 0x01)
+  vac_buf[3] = 0x00;  // vacation_active = 0
   send_write_request(ADDR_TSTAT, TBL_SAM_INFO, ROW_SAM_VACATION,
-                     vac_buf, 8);
+                     vac_buf, 11);
   ESP_LOGI(TAG, "Deactivating vacation mode");
 }
 

--- a/components/abcdesp/abcdesp.cpp
+++ b/components/abcdesp/abcdesp.cpp
@@ -797,8 +797,7 @@ void AbcdEspComponent::parse_heatpump_02(const uint8_t *data,
 }
 
 // ==========================================================================
-// Parse 3B04 — vacation settings (11 bytes)
-// Layout (confirmed via hardware logs):
+// Parse 3B04 — vacation settings (11 bytes)d// Layout (confirmed via hardware logs):
 //   [0]    = zone count/status (always 0x01, NOT vacation flag)
 //   [1-2]  = unknown (always 0x00)
 //   [3]    = vacation_active (0=off, 1=on)
@@ -868,6 +867,7 @@ void AbcdEspComponent::parse_vacation(const uint8_t *data, uint8_t len) {
 climate::ClimateTraits AbcdEspComponent::traits() {
   auto traits = climate::ClimateTraits();
   traits.add_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE |
+                           climate::CLIMATE_SUPPORTS_TARGET_TEMPERATURE |
                            climate::CLIMATE_SUPPORTS_TWO_POINT_TARGET_TEMPERATURE);
   traits.set_visual_min_temperature(f_to_c(40));   // 40°F ≈ 4.4°C
   traits.set_visual_max_temperature(f_to_c(99));   // 99°F ≈ 37.2°C
@@ -1109,17 +1109,30 @@ void AbcdEspComponent::publish_climate_state() {
   }
 
   // Target temperatures (convert °F → °C for HA)
-  // Always use dual target (low/high) because traits declares
-  // TWO_POINT_TARGET_TEMPERATURE — ESPHome ignores single target when
-  // that flag is set.  The thermostat always maintains both setpoints.
-  if (this->mode == climate::CLIMATE_MODE_OFF) {
-    this->target_temperature_low = NAN;
-    this->target_temperature_high = NAN;
-  } else {
-    this->target_temperature_low = f_to_c(static_cast<float>(heat_setpoint_));
-    this->target_temperature_high = f_to_c(static_cast<float>(cool_setpoint_));
+  // With both TARGET_TEMPERATURE and TWO_POINT_TARGET_TEMPERATURE declared,
+  // ESPHome uses single target in HEAT/COOL and dual in HEAT_COOL.
+  switch (this->mode) {
+    case climate::CLIMATE_MODE_HEAT:
+      this->target_temperature = f_to_c(static_cast<float>(heat_setpoint_));
+      this->target_temperature_low = NAN;
+      this->target_temperature_high = NAN;
+      break;
+    case climate::CLIMATE_MODE_COOL:
+      this->target_temperature = f_to_c(static_cast<float>(cool_setpoint_));
+      this->target_temperature_low = NAN;
+      this->target_temperature_high = NAN;
+      break;
+    case climate::CLIMATE_MODE_HEAT_COOL:
+      this->target_temperature_low = f_to_c(static_cast<float>(heat_setpoint_));
+      this->target_temperature_high = f_to_c(static_cast<float>(cool_setpoint_));
+      this->target_temperature = NAN;
+      break;
+    default:
+      this->target_temperature = NAN;
+      this->target_temperature_low = NAN;
+      this->target_temperature_high = NAN;
+      break;
   }
-  this->target_temperature = NAN;
 
   // Fan mode
   switch (fan_mode_) {

--- a/tests/test_protocol.cpp
+++ b/tests/test_protocol.cpp
@@ -745,9 +745,9 @@ TEST(setpoint_f_to_c_rounding) {
 
 TEST(target_temp_clear_stale_on_mode_switch) {
   printf("test_target_temp_clear_stale_on_mode_switch\n");
-  // With both TARGET_TEMPERATURE and TWO_POINT_TARGET_TEMPERATURE declared,
-  // ESPHome uses single target in HEAT/COOL, dual in HEAT_COOL (auto).
-  // Unused fields must be NaN to avoid stale values.
+  // With TWO_POINT_TARGET_TEMPERATURE, always use dual targets (low/high).
+  // HA thermostat card shows the relevant slider based on mode.
+  // Single target_temperature is always NaN.
 
   uint8_t heat_setpoint = 68;
   uint8_t cool_setpoint = 76;
@@ -757,48 +757,34 @@ TEST(target_temp_clear_stale_on_mode_switch) {
 
   // Helper lambda mirrors publish_climate_state logic
   auto update_targets = [&](int mode) {
-    // mode: 0=OFF, 1=HEAT, 2=COOL, 3=AUTO
-    switch (mode) {
-      case 1:  // HEAT — single target
-        target_temperature = f_to_c(static_cast<float>(heat_setpoint));
-        target_temperature_low = NAN;
-        target_temperature_high = NAN;
-        break;
-      case 2:  // COOL — single target
-        target_temperature = f_to_c(static_cast<float>(cool_setpoint));
-        target_temperature_low = NAN;
-        target_temperature_high = NAN;
-        break;
-      case 3:  // AUTO — dual targets
-        target_temperature_low = f_to_c(static_cast<float>(heat_setpoint));
-        target_temperature_high = f_to_c(static_cast<float>(cool_setpoint));
-        target_temperature = NAN;
-        break;
-      default:  // OFF — all NaN
-        target_temperature = NAN;
-        target_temperature_low = NAN;
-        target_temperature_high = NAN;
-        break;
+    // mode: 0=OFF, else=any active mode
+    if (mode == 0) {
+      target_temperature_low = NAN;
+      target_temperature_high = NAN;
+    } else {
+      target_temperature_low = f_to_c(static_cast<float>(heat_setpoint));
+      target_temperature_high = f_to_c(static_cast<float>(cool_setpoint));
     }
+    target_temperature = NAN;  // always NaN with two-point
   };
 
-  // AUTO mode — dual targets, single NaN
-  update_targets(3);
+  // HEAT mode — both low/high set
+  update_targets(1);
   ASSERT_TRUE(!std::isnan(target_temperature_low));
   ASSERT_TRUE(!std::isnan(target_temperature_high));
   ASSERT_TRUE(std::isnan(target_temperature));
 
-  // HEAT mode — single target, dual NaN
-  update_targets(1);
-  ASSERT_TRUE(!std::isnan(target_temperature));
-  ASSERT_TRUE(std::isnan(target_temperature_low));
-  ASSERT_TRUE(std::isnan(target_temperature_high));
-
-  // COOL mode — single target, dual NaN
+  // COOL mode — both low/high set
   update_targets(2);
-  ASSERT_TRUE(!std::isnan(target_temperature));
-  ASSERT_TRUE(std::isnan(target_temperature_low));
-  ASSERT_TRUE(std::isnan(target_temperature_high));
+  ASSERT_TRUE(!std::isnan(target_temperature_low));
+  ASSERT_TRUE(!std::isnan(target_temperature_high));
+  ASSERT_TRUE(std::isnan(target_temperature));
+
+  // AUTO mode — both low/high set
+  update_targets(3);
+  ASSERT_TRUE(!std::isnan(target_temperature_low));
+  ASSERT_TRUE(!std::isnan(target_temperature_high));
+  ASSERT_TRUE(std::isnan(target_temperature));
 
   // OFF mode — all NaN
   update_targets(0);

--- a/tests/test_protocol.cpp
+++ b/tests/test_protocol.cpp
@@ -745,9 +745,9 @@ TEST(setpoint_f_to_c_rounding) {
 
 TEST(target_temp_clear_stale_on_mode_switch) {
   printf("test_target_temp_clear_stale_on_mode_switch\n");
-  // With TWO_POINT_TARGET_TEMPERATURE, we always use dual targets.
-  // Single target_temperature is always NaN.
-  // In OFF mode, both low and high are NaN.
+  // With both TARGET_TEMPERATURE and TWO_POINT_TARGET_TEMPERATURE declared,
+  // ESPHome uses single target in HEAT/COOL, dual in HEAT_COOL (auto).
+  // Unused fields must be NaN to avoid stale values.
 
   uint8_t heat_setpoint = 68;
   uint8_t cool_setpoint = 76;
@@ -758,33 +758,47 @@ TEST(target_temp_clear_stale_on_mode_switch) {
   // Helper lambda mirrors publish_climate_state logic
   auto update_targets = [&](int mode) {
     // mode: 0=OFF, 1=HEAT, 2=COOL, 3=AUTO
-    if (mode == 0) {
-      target_temperature_low = NAN;
-      target_temperature_high = NAN;
-    } else {
-      target_temperature_low = f_to_c(static_cast<float>(heat_setpoint));
-      target_temperature_high = f_to_c(static_cast<float>(cool_setpoint));
+    switch (mode) {
+      case 1:  // HEAT — single target
+        target_temperature = f_to_c(static_cast<float>(heat_setpoint));
+        target_temperature_low = NAN;
+        target_temperature_high = NAN;
+        break;
+      case 2:  // COOL — single target
+        target_temperature = f_to_c(static_cast<float>(cool_setpoint));
+        target_temperature_low = NAN;
+        target_temperature_high = NAN;
+        break;
+      case 3:  // AUTO — dual targets
+        target_temperature_low = f_to_c(static_cast<float>(heat_setpoint));
+        target_temperature_high = f_to_c(static_cast<float>(cool_setpoint));
+        target_temperature = NAN;
+        break;
+      default:  // OFF — all NaN
+        target_temperature = NAN;
+        target_temperature_low = NAN;
+        target_temperature_high = NAN;
+        break;
     }
-    target_temperature = NAN;  // always NaN with two-point
   };
 
-  // AUTO mode — both targets set
+  // AUTO mode — dual targets, single NaN
   update_targets(3);
   ASSERT_TRUE(!std::isnan(target_temperature_low));
   ASSERT_TRUE(!std::isnan(target_temperature_high));
   ASSERT_TRUE(std::isnan(target_temperature));
 
-  // HEAT mode — still both targets (thermostat always has both setpoints)
+  // HEAT mode — single target, dual NaN
   update_targets(1);
-  ASSERT_TRUE(!std::isnan(target_temperature_low));
-  ASSERT_TRUE(!std::isnan(target_temperature_high));
-  ASSERT_TRUE(std::isnan(target_temperature));
+  ASSERT_TRUE(!std::isnan(target_temperature));
+  ASSERT_TRUE(std::isnan(target_temperature_low));
+  ASSERT_TRUE(std::isnan(target_temperature_high));
 
-  // COOL mode — still both targets
+  // COOL mode — single target, dual NaN
   update_targets(2);
-  ASSERT_TRUE(!std::isnan(target_temperature_low));
-  ASSERT_TRUE(!std::isnan(target_temperature_high));
-  ASSERT_TRUE(std::isnan(target_temperature));
+  ASSERT_TRUE(!std::isnan(target_temperature));
+  ASSERT_TRUE(std::isnan(target_temperature_low));
+  ASSERT_TRUE(std::isnan(target_temperature_high));
 
   // OFF mode — all NaN
   update_targets(0);

--- a/tests/test_protocol.cpp
+++ b/tests/test_protocol.cpp
@@ -540,52 +540,63 @@ TEST(fan_mode_encoding) {
 
 TEST(parse_vacation_3b04) {
   printf("test_parse_vacation_3b04\n");
-  // 3B04: [0]=vacation_active, [1-2]=days*7(BE), [3]=mintemp, [4]=maxtemp,
-  //       [5]=minhumidity, [6]=maxhumidity, [7]=fanmode
-  uint8_t data[8] = {0};
-  data[0] = 0x01;  // vacation active
-  data[1] = 0x00;  // days*7 high (7 days = 49 = 0x0031)
-  data[2] = 0x31;  // days*7 low
-  data[3] = 55;    // min temp
-  data[4] = 85;    // max temp
-  data[5] = 15;    // min humidity
-  data[6] = 60;    // max humidity
-  data[7] = FAN_AUTO;
+  // 3B04 layout (confirmed via hardware logs):
+  //   [0]    = zone count/status (always 0x01)
+  //   [1-2]  = unknown (always 0x00)
+  //   [3]    = vacation_active (0=off, 1=on)
+  //   [4-5]  = hours remaining (uint16 BE)
+  //   [6]    = min temp (°F)
+  //   [7]    = max temp (°F)
+  //   [8]    = min humidity (%)
+  //   [9]    = max humidity (%)
+  //   [10]   = fan mode
+  uint8_t data[11] = {0};
+  data[0] = 0x01;  // zone count (always 1)
+  data[3] = 0x01;  // vacation active
+  data[4] = 0x00;  // hours high (168 = 7 days * 24)
+  data[5] = 0xA8;  // hours low (0x00A8 = 168)
+  data[6] = 55;    // min temp
+  data[7] = 85;    // max temp
+  data[8] = 15;    // min humidity
+  data[9] = 60;    // max humidity
+  data[10] = FAN_AUTO;
 
-  ASSERT_EQ(data[0], 1);  // vacation active
-  uint16_t days_times7 = (data[1] << 8) | data[2];
-  ASSERT_EQ(days_times7, 49);  // 7 days * 7
-  ASSERT_EQ(data[3], 55);
-  ASSERT_EQ(data[4], 85);
-  ASSERT_EQ(data[5], 15);
-  ASSERT_EQ(data[6], 60);
-  ASSERT_EQ(data[7], FAN_AUTO);
+  // Vacation active flag is byte 3, not byte 0
+  bool vacation_active = (data[3] != 0);
+  ASSERT_TRUE(vacation_active);
 
-  // Inactive vacation
-  data[0] = 0x00;
-  ASSERT_EQ(data[0], 0);
+  uint16_t hours = (data[4] << 8) | data[5];
+  ASSERT_EQ(hours, 168);  // 7 days * 24
+  uint8_t vac_days = hours / 24;
+  ASSERT_EQ(vac_days, 7);
+  ASSERT_EQ(data[6], 55);
+  ASSERT_EQ(data[7], 85);
+  ASSERT_EQ(data[8], 15);
+  ASSERT_EQ(data[9], 60);
+  ASSERT_EQ(data[10], FAN_AUTO);
 
-  // Byte 0 non-zero but days=0 — should NOT be considered active
-  // (thermostat may keep byte 0 set after vacation expires)
-  data[0] = 0x01;
-  data[1] = 0x00;
-  data[2] = 0x00;  // days*7 = 0
-  days_times7 = (data[1] << 8) | data[2];
-  bool vacation_active = (data[0] != 0);
-  if (vacation_active && days_times7 == 0) {
-    vacation_active = false;
-  }
+  // Inactive vacation — byte 3 = 0
+  data[3] = 0x00;
+  vacation_active = (data[3] != 0);
   ASSERT_TRUE(!vacation_active);
 
-  // Byte 0 non-zero AND days > 0 — genuinely active
-  data[0] = 0x01;
-  data[1] = 0x00;
-  data[2] = 0x07;  // days*7 = 7 (1 day)
-  days_times7 = (data[1] << 8) | data[2];
-  vacation_active = (data[0] != 0);
-  if (vacation_active && days_times7 == 0) {
-    vacation_active = false;
-  }
+  // Byte 0 always 0x01 regardless of vacation state
+  ASSERT_EQ(data[0], 0x01);
+
+  // 2-day vacation: 48 hours = 0x0030
+  data[3] = 0x01;
+  data[4] = 0x00;
+  data[5] = 0x30;  // 48 hours
+  hours = (data[4] << 8) | data[5];
+  ASSERT_EQ(hours, 48);
+  ASSERT_EQ(hours / 24, 2);
+
+  // Vacation active with 0 hours — still active per byte 3
+  // (thermostat may report 0 hours briefly during activation)
+  data[3] = 0x01;
+  data[4] = 0x00;
+  data[5] = 0x00;
+  vacation_active = (data[3] != 0);
   ASSERT_TRUE(vacation_active);
   PASS();
 }
@@ -734,8 +745,9 @@ TEST(setpoint_f_to_c_rounding) {
 
 TEST(target_temp_clear_stale_on_mode_switch) {
   printf("test_target_temp_clear_stale_on_mode_switch\n");
-  // When switching from AUTO (dual target) to HEAT or COOL (single target),
-  // the unused target fields must be NaN so HA doesn't show stale values.
+  // With TWO_POINT_TARGET_TEMPERATURE, we always use dual targets.
+  // Single target_temperature is always NaN.
+  // In OFF mode, both low and high are NaN.
 
   uint8_t heat_setpoint = 68;
   uint8_t cool_setpoint = 76;
@@ -743,34 +755,39 @@ TEST(target_temp_clear_stale_on_mode_switch) {
   float target_temperature_low = NAN;
   float target_temperature_high = NAN;
 
-  // Simulate AUTO mode — sets dual targets, clears single
-  target_temperature_low = f_to_c(static_cast<float>(heat_setpoint));
-  target_temperature_high = f_to_c(static_cast<float>(cool_setpoint));
-  target_temperature = NAN;
+  // Helper lambda mirrors publish_climate_state logic
+  auto update_targets = [&](int mode) {
+    // mode: 0=OFF, 1=HEAT, 2=COOL, 3=AUTO
+    if (mode == 0) {
+      target_temperature_low = NAN;
+      target_temperature_high = NAN;
+    } else {
+      target_temperature_low = f_to_c(static_cast<float>(heat_setpoint));
+      target_temperature_high = f_to_c(static_cast<float>(cool_setpoint));
+    }
+    target_temperature = NAN;  // always NaN with two-point
+  };
+
+  // AUTO mode — both targets set
+  update_targets(3);
   ASSERT_TRUE(!std::isnan(target_temperature_low));
   ASSERT_TRUE(!std::isnan(target_temperature_high));
   ASSERT_TRUE(std::isnan(target_temperature));
 
-  // Simulate switching to COOL mode — must clear dual targets
-  target_temperature = f_to_c(static_cast<float>(cool_setpoint));
-  target_temperature_low = NAN;
-  target_temperature_high = NAN;
-  ASSERT_TRUE(!std::isnan(target_temperature));
-  ASSERT_TRUE(std::isnan(target_temperature_low));   // must be NaN
-  ASSERT_TRUE(std::isnan(target_temperature_high));  // must be NaN
+  // HEAT mode — still both targets (thermostat always has both setpoints)
+  update_targets(1);
+  ASSERT_TRUE(!std::isnan(target_temperature_low));
+  ASSERT_TRUE(!std::isnan(target_temperature_high));
+  ASSERT_TRUE(std::isnan(target_temperature));
 
-  // Simulate switching to HEAT mode — must clear dual targets
-  target_temperature = f_to_c(static_cast<float>(heat_setpoint));
-  target_temperature_low = NAN;
-  target_temperature_high = NAN;
-  ASSERT_TRUE(!std::isnan(target_temperature));
-  ASSERT_TRUE(std::isnan(target_temperature_low));
-  ASSERT_TRUE(std::isnan(target_temperature_high));
+  // COOL mode — still both targets
+  update_targets(2);
+  ASSERT_TRUE(!std::isnan(target_temperature_low));
+  ASSERT_TRUE(!std::isnan(target_temperature_high));
+  ASSERT_TRUE(std::isnan(target_temperature));
 
-  // Simulate switching to OFF — all NaN
-  target_temperature = NAN;
-  target_temperature_low = NAN;
-  target_temperature_high = NAN;
+  // OFF mode — all NaN
+  update_targets(0);
   ASSERT_TRUE(std::isnan(target_temperature));
   ASSERT_TRUE(std::isnan(target_temperature_low));
   ASSERT_TRUE(std::isnan(target_temperature_high));
@@ -1417,102 +1434,106 @@ TEST(hold_duration_number_overrides_config) {
 // ---------------------------------------------------------------------------
 
 // Helper: build a vacation activation payload using configurable parameters.
-// Mirrors the control() logic.
+// Mirrors the activate_vacation() logic with corrected 11-byte layout.
 static void build_vacation_payload(uint8_t days, uint8_t min_temp,
                                    uint8_t max_temp, uint8_t *vac_buf) {
-  uint16_t days_x7 = static_cast<uint16_t>(days) * 7;
-  vac_buf[0] = 0x01;                       // vacation_active = 1
-  vac_buf[1] = (days_x7 >> 8) & 0xFF;      // days*7 high byte
-  vac_buf[2] = days_x7 & 0xFF;             // days*7 low byte
-  vac_buf[3] = min_temp;                   // min temp °F
-  vac_buf[4] = max_temp;                   // max temp °F
-  vac_buf[5] = 15;                         // min humidity
-  vac_buf[6] = 60;                         // max humidity
-  vac_buf[7] = FAN_AUTO;
+  uint16_t hours = static_cast<uint16_t>(days) * 24;
+  memset(vac_buf, 0, 11);
+  vac_buf[0] = 0x01;                       // zone count/status
+  vac_buf[3] = 0x01;                       // vacation_active = 1
+  vac_buf[4] = (hours >> 8) & 0xFF;        // hours high byte
+  vac_buf[5] = hours & 0xFF;               // hours low byte
+  vac_buf[6] = min_temp;                   // min temp °F
+  vac_buf[7] = max_temp;                   // max temp °F
+  vac_buf[8] = 15;                         // min humidity
+  vac_buf[9] = 60;                         // max humidity
+  vac_buf[10] = FAN_AUTO;
 }
 
 TEST(build_vacation_payload_defaults) {
   printf("test_build_vacation_payload_defaults\n");
   // Default vacation: 7 days, 60-80°F
-  uint8_t buf[8];
+  uint8_t buf[11];
   build_vacation_payload(7, 60, 80, buf);
 
-  ASSERT_EQ(buf[0], 0x01);  // active
-  // 7 * 7 = 49 = 0x0031
-  ASSERT_EQ(buf[1], 0x00);
-  ASSERT_EQ(buf[2], 0x31);
-  ASSERT_EQ(buf[3], 60);
-  ASSERT_EQ(buf[4], 80);
-  ASSERT_EQ(buf[5], 15);
+  ASSERT_EQ(buf[0], 0x01);  // zone count
+  ASSERT_EQ(buf[3], 0x01);  // active
+  // 7 * 24 = 168 = 0x00A8
+  uint16_t hours = (buf[4] << 8) | buf[5];
+  ASSERT_EQ(hours, 168);
   ASSERT_EQ(buf[6], 60);
-  ASSERT_EQ(buf[7], FAN_AUTO);
+  ASSERT_EQ(buf[7], 80);
+  ASSERT_EQ(buf[8], 15);
+  ASSERT_EQ(buf[9], 60);
+  ASSERT_EQ(buf[10], FAN_AUTO);
   PASS();
 }
 
 TEST(build_vacation_payload_custom) {
   printf("test_build_vacation_payload_custom\n");
   // Custom: 14 days, 55-85°F
-  uint8_t buf[8];
+  uint8_t buf[11];
   build_vacation_payload(14, 55, 85, buf);
 
-  ASSERT_EQ(buf[0], 0x01);
-  // 14 * 7 = 98 = 0x0062
-  uint16_t days_x7 = (buf[1] << 8) | buf[2];
-  ASSERT_EQ(days_x7, 98);
-  ASSERT_EQ(buf[3], 55);
-  ASSERT_EQ(buf[4], 85);
+  ASSERT_EQ(buf[0], 0x01);  // zone count
+  ASSERT_EQ(buf[3], 0x01);  // active
+  // 14 * 24 = 336 = 0x0150
+  uint16_t hours = (buf[4] << 8) | buf[5];
+  ASSERT_EQ(hours, 336);
+  ASSERT_EQ(buf[6], 55);
+  ASSERT_EQ(buf[7], 85);
   PASS();
 }
 
 TEST(build_vacation_payload_boundary_days) {
   printf("test_build_vacation_payload_boundary_days\n");
-  uint8_t buf[8];
+  uint8_t buf[11];
 
   // 1 day (minimum)
   build_vacation_payload(1, 60, 80, buf);
-  uint16_t days_x7 = (buf[1] << 8) | buf[2];
-  ASSERT_EQ(days_x7, 7);  // 1 * 7
+  uint16_t hours = (buf[4] << 8) | buf[5];
+  ASSERT_EQ(hours, 24);  // 1 * 24
 
   // 30 days (maximum)
   build_vacation_payload(30, 60, 80, buf);
-  days_x7 = (buf[1] << 8) | buf[2];
-  ASSERT_EQ(days_x7, 210);  // 30 * 7 = 0x00D2
-  ASSERT_EQ(buf[1], 0x00);
-  ASSERT_EQ(buf[2], 0xD2);
+  hours = (buf[4] << 8) | buf[5];
+  ASSERT_EQ(hours, 720);  // 30 * 24 = 0x02D0
+  ASSERT_EQ(buf[4], 0x02);
+  ASSERT_EQ(buf[5], 0xD0);
   PASS();
 }
 
 TEST(build_vacation_payload_boundary_temps) {
   printf("test_build_vacation_payload_boundary_temps\n");
-  uint8_t buf[8];
+  uint8_t buf[11];
 
   // Min temp = 40, max temp = 99
   build_vacation_payload(7, 40, 99, buf);
-  ASSERT_EQ(buf[3], 40);
-  ASSERT_EQ(buf[4], 99);
+  ASSERT_EQ(buf[6], 40);
+  ASSERT_EQ(buf[7], 99);
 
   // Narrow range: 70-72
   build_vacation_payload(7, 70, 72, buf);
-  ASSERT_EQ(buf[3], 70);
-  ASSERT_EQ(buf[4], 72);
+  ASSERT_EQ(buf[6], 70);
+  ASSERT_EQ(buf[7], 72);
   PASS();
 }
 
 TEST(build_vacation_payload_frame_roundtrip) {
   printf("test_build_vacation_payload_frame_roundtrip\n");
   // Build a vacation payload, wrap in WRITE frame, verify roundtrip
-  uint8_t vac_buf[8];
+  uint8_t vac_buf[11];
   build_vacation_payload(10, 58, 78, vac_buf);
 
   InfinityFrame f;
   f.dst = ADDR_TSTAT;
   f.src = ADDR_SAM;
   f.func = FUNC_WRITE;
-  f.length = 3 + 8;
+  f.length = 3 + 11;
   f.data[0] = 0x00;
   f.data[1] = 0x3B;
   f.data[2] = 0x04;
-  memcpy(f.data + 3, vac_buf, 8);
+  memcpy(f.data + 3, vac_buf, 11);
 
   uint8_t frame_buf[32];
   uint16_t frame_len;
@@ -1521,12 +1542,13 @@ TEST(build_vacation_payload_frame_roundtrip) {
   InfinityFrame parsed;
   ASSERT_TRUE(parse_frame(frame_buf, frame_len, parsed));
   ASSERT_EQ(parsed.func, FUNC_WRITE);
-  ASSERT_EQ(parsed.data[3], 0x01);   // active
-  ASSERT_EQ(parsed.data[3 + 3], 58); // min temp
-  ASSERT_EQ(parsed.data[3 + 4], 78); // max temp
-  // 10 * 7 = 70
-  uint16_t days_x7 = (parsed.data[3 + 1] << 8) | parsed.data[3 + 2];
-  ASSERT_EQ(days_x7, 70);
+  ASSERT_EQ(parsed.data[3], 0x01);     // zone count
+  ASSERT_EQ(parsed.data[3 + 3], 0x01); // vacation active
+  ASSERT_EQ(parsed.data[3 + 6], 58);   // min temp
+  ASSERT_EQ(parsed.data[3 + 7], 78);   // max temp
+  // 10 * 24 = 240 = 0x00F0
+  uint16_t hours = (parsed.data[3 + 4] << 8) | parsed.data[3 + 5];
+  ASSERT_EQ(hours, 240);
   PASS();
 }
 
@@ -1568,47 +1590,57 @@ TEST(vacation_number_fallback_logic) {
 
 TEST(parse_vacation_3b04_fields) {
   printf("test_parse_vacation_3b04_fields\n");
-  // Verify parsing of 3B04 register content
-  uint8_t data[8] = {0};
+  // Verify parsing of 3B04 register content with corrected layout
+  // [0]=zone, [3]=active, [4-5]=hours(BE), [6]=min, [7]=max
+  uint8_t data[11] = {0};
 
-  // Active vacation: 10 days, 58-78°F
-  data[0] = 0x01;  // active
-  uint16_t days_x7 = 10 * 7;  // 70
-  data[1] = (days_x7 >> 8) & 0xFF;
-  data[2] = days_x7 & 0xFF;
-  data[3] = 58;  // min temp
-  data[4] = 78;  // max temp
-  data[5] = 15;  // min humidity
-  data[6] = 60;  // max humidity
-  data[7] = FAN_AUTO;
+  // Active vacation: 10 days (240 hours), 58-78°F
+  data[0] = 0x01;  // zone count (always 1)
+  data[3] = 0x01;  // active
+  uint16_t hours = 10 * 24;  // 240
+  data[4] = (hours >> 8) & 0xFF;
+  data[5] = hours & 0xFF;
+  data[6] = 58;  // min temp
+  data[7] = 78;  // max temp
+  data[8] = 15;  // min humidity
+  data[9] = 60;  // max humidity
+  data[10] = FAN_AUTO;
 
   // Parse fields like parse_vacation does
-  bool active = (data[0] != 0);
+  bool active = (data[3] != 0);
   ASSERT_TRUE(active);
 
-  uint16_t parsed_days_x7 = (data[1] << 8) | data[2];
-  uint8_t parsed_days = (parsed_days_x7 > 0) ? (parsed_days_x7 / 7) : 0;
+  uint16_t parsed_hours = (data[4] << 8) | data[5];
+  uint8_t parsed_days = parsed_hours / 24;
+  ASSERT_EQ(parsed_hours, 240);
   ASSERT_EQ(parsed_days, 10);
-  ASSERT_EQ(data[3], 58);
-  ASSERT_EQ(data[4], 78);
+  ASSERT_EQ(data[6], 58);
+  ASSERT_EQ(data[7], 78);
 
-  // Inactive vacation
-  data[0] = 0x00;
-  active = (data[0] != 0);
+  // Inactive vacation — byte 3 = 0
+  data[3] = 0x00;
+  active = (data[3] != 0);
   ASSERT_TRUE(!active);
+
+  // Byte 0 remains 0x01 even when inactive
+  ASSERT_EQ(data[0], 0x01);
   PASS();
 }
 
 TEST(vacation_deactivation_payload) {
   printf("test_vacation_deactivation_payload\n");
-  // Verify the deactivation payload structure
-  uint8_t vac_buf[8];
+  // Verify the deactivation payload structure (11 bytes)
+  uint8_t vac_buf[11];
   memset(vac_buf, 0, sizeof(vac_buf));
-  vac_buf[0] = 0x00;  // vacation_active = 0
+  vac_buf[0] = 0x01;  // zone count (always 0x01)
+  vac_buf[3] = 0x00;  // vacation_active = 0
 
-  ASSERT_EQ(vac_buf[0], 0x00);
-  // All other bytes should be zero
-  for (int i = 1; i < 8; i++) {
+  ASSERT_EQ(vac_buf[0], 0x01);  // zone count preserved
+  ASSERT_EQ(vac_buf[3], 0x00);  // inactive
+  // Bytes 1-2, 4-10 should be zero
+  ASSERT_EQ(vac_buf[1], 0);
+  ASSERT_EQ(vac_buf[2], 0);
+  for (int i = 4; i < 11; i++) {
     ASSERT_EQ(vac_buf[i], 0);
   }
 
@@ -1617,11 +1649,11 @@ TEST(vacation_deactivation_payload) {
   f.dst = ADDR_TSTAT;
   f.src = ADDR_SAM;
   f.func = FUNC_WRITE;
-  f.length = 3 + 8;
+  f.length = 3 + 11;
   f.data[0] = 0x00;
   f.data[1] = 0x3B;
   f.data[2] = 0x04;
-  memcpy(f.data + 3, vac_buf, 8);
+  memcpy(f.data + 3, vac_buf, 11);
 
   uint8_t buf[32];
   uint16_t buf_len;
@@ -1629,7 +1661,8 @@ TEST(vacation_deactivation_payload) {
 
   InfinityFrame parsed;
   ASSERT_TRUE(parse_frame(buf, buf_len, parsed));
-  ASSERT_EQ(parsed.data[3], 0x00);  // inactive
+  ASSERT_EQ(parsed.data[3], 0x01);  // zone count byte
+  ASSERT_EQ(parsed.data[6], 0x00);  // vacation inactive (byte 3 of payload)
   PASS();
 }
 


### PR DESCRIPTION
## Summary

Fixes vacation detection (never worked) and target temperature display (always showed NaN), based on hardware log analysis from April 24 test session.

### Bug 1 — Vacation detection completely wrong byte layout

Hardware logs with the hex dump (added in PR #33) revealed the 3B04 register layout is completely different from what was assumed:

| Byte | Old assumption | Actual (from logs) |
|------|---------------|-------------------|
| [0] | vacation_active | zone count (always 0x01) |
| [1-2] | days×7 (BE) | unknown (always 0x00) |
| [3] | min temp | **vacation_active** (0/1) |
| [4-5] | max temp, humidity | **hours remaining** (BE uint16) |
| [6] | humidity | min temp (°F) |
| [7] | fan mode | max temp (°F) |
| [8-9] | — | humidity (min/max) |
| [10] | — | fan mode |

Evidence from logs:
- Before vacation: `01 00 00 00 00 00 43 50 0F 3C 00`
- During 2-day vacation: `01 00 00 01 00 30 43 50 0F 3C 00` (byte 3=1, hours=0x30=48=2×24)
- After cancel: `01 00 00 00 00 00 43 50 0F 3C 00`

Fixed both the read parser and write payloads (activate/cancel) to use correct 11-byte layout.

### Bug 2 — Target temperature always NaN

The climate entity declared `CLIMATE_SUPPORTS_TWO_POINT_TARGET_TEMPERATURE` in traits, but `publish_climate_state()` used single `target_temperature` in HEAT/COOL modes. ESPHome ignores single target when only two-point is declared, so HA never saw a setpoint.

Fix: always use `target_temperature_low`/`target_temperature_high` in all non-OFF modes, since the thermostat always maintains both heat and cool setpoints.

### Tests updated
- `parse_vacation_3b04` — rewritten for correct byte layout (byte 3 = active, bytes 4-5 = hours)
- `parse_vacation_3b04_fields` — updated field offsets and hours-based duration
- `build_vacation_payload_*` — all updated for 11-byte layout with hours
- `vacation_deactivation_payload` — updated for 11-byte layout with zone count
- `target_temp_clear_stale_on_mode_switch` — rewritten for always-dual-target logic